### PR TITLE
build: migrate to hatchling + add PyPI release workflows

### DIFF
--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -1,0 +1,81 @@
+name: Publish Python Package
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  call-test-lint:
+    uses: ./.github/workflows/test-lint.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.event.release.target_commitish }}
+
+  build:
+    name: Build distribution
+    permissions:
+      contents: read
+    needs:
+      - call-test-lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch twine
+
+      - name: Validate version
+        run: |
+          version=$(hatch version)
+          if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Valid version format"
+              exit 0
+          else
+              echo "Invalid version format"
+              exit 1
+          fi
+
+      - name: Build
+        run: |
+          hatch build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  deploy:
+    name: Upload release to PyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/harness-optimizer
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # release/v1

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -1,0 +1,38 @@
+name: Test and Lint
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+
+jobs:
+  test-lint:
+    name: Test and Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          pip install --no-cache-dir hatch
+          pip install --no-cache-dir -e ".[dev]"
+
+      - name: Run lint
+        run: hatch run lint
+
+      - name: Run tests
+        run: hatch run test -x --strict-markers

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ docs/.astro/
 # Docker
 Dockerfile
 .dockerignore
+
+# hatch-vcs generated
+harness_optimizer/_version.py

--- a/harness_optimizer/__init__.py
+++ b/harness_optimizer/__init__.py
@@ -2,7 +2,10 @@
 Harness Optimizer — A framework for optimizing LLM agent context through Formulas.
 """
 
-__version__ = "0.1.0"
+try:
+    from ._version import __version__
+except ImportError:  # pragma: no cover - fallback when not built via hatch-vcs
+    __version__ = "0.0.0.dev0"
 
 # Load compat module to register legacy import paths (e.g., harness_optimizer.processors)
-from . import compat as _compat  # noqa: F401
+from . import compat as _compat  # noqa: F401,E402

--- a/harness_optimizer/adapters/__init__.py
+++ b/harness_optimizer/adapters/__init__.py
@@ -1,7 +1,11 @@
 """Agent framework adapters — bridge formulas to agent frameworks."""
 
 from .agent_adapter import AgentAdapter
-from .strands_adapter import StrandsAdapter, StrandsAgentWithFormulas, apply_formulas_on_strands_agent
+from .strands_adapter import (
+    StrandsAdapter,
+    StrandsAgentWithFormulas,
+    apply_formulas_on_strands_agent,
+)
 
 __all__ = [
     "AgentAdapter",

--- a/harness_optimizer/adapters/strands_adapter.py
+++ b/harness_optimizer/adapters/strands_adapter.py
@@ -112,12 +112,11 @@ class StrandsAdapter(AgentAdapter):
                         if f.can_process(context):
                             updated = f.process(context)
                             self.update_context(event.agent, updated)
+
                     return callback
 
                 agent.add_hook(_make_callback(formula), event_type)
-                logger.info(
-                    f"Registered formula '{formula.name}' on {event_type.__name__}"
-                )
+                logger.info(f"Registered formula '{formula.name}' on {event_type.__name__}")
 
         return agent
 

--- a/harness_optimizer/compat.py
+++ b/harness_optimizer/compat.py
@@ -20,6 +20,7 @@ sys.modules[f"{_parent}.processors"] = sys.modules[__name__]
 
 def _get_aliases():
     from .formulas import Formula, SystemPromptFormula
+
     return {
         "ContextUnitProcessor": Formula,
         "SystemPromptProcessor": SystemPromptFormula,

--- a/harness_optimizer/data/__init__.py
+++ b/harness_optimizer/data/__init__.py
@@ -1,8 +1,8 @@
 """Data loading — PyTorch-style Dataset, Sampler, and DataLoader (stdlib adapted)."""
 
+from .dataloader import DataLoader
 from .dataset import ChainDataset, Dataset, IterableDataset, Subset
 from .sampler import BatchSampler, RandomSampler, Sampler, SequentialSampler
-from .dataloader import DataLoader
 
 __all__ = [
     "Dataset",

--- a/harness_optimizer/data/dataset.py
+++ b/harness_optimizer/data/dataset.py
@@ -9,7 +9,6 @@ See: https://github.com/pytorch/pytorch/blob/main/torch/utils/data/dataset.py
 
 from typing import Generic, Iterable, Sequence, TypeVar
 
-
 _T_co = TypeVar("_T_co", covariant=True)
 
 
@@ -26,7 +25,9 @@ class Dataset(Generic[_T_co]):
         raise NotImplementedError("Subclasses of Dataset should implement __getitem__.")
 
     def __add__(self, other: "Dataset[_T_co]") -> "Dataset[_T_co]":
-        raise NotImplementedError("Use ChainDataset for IterableDatasets or Subset for map-style Datasets.")
+        raise NotImplementedError(
+            "Use ChainDataset for IterableDatasets or Subset for map-style Datasets."
+        )
 
 
 class IterableDataset(Dataset[_T_co], Iterable[_T_co]):

--- a/harness_optimizer/data/sampler.py
+++ b/harness_optimizer/data/sampler.py
@@ -11,7 +11,6 @@ import itertools
 import random
 from typing import Generic, Iterable, Iterator, List, Optional, Sized, TypeVar, Union
 
-
 _T_co = TypeVar("_T_co", covariant=True)
 
 
@@ -130,9 +129,7 @@ class BatchSampler(Sampler[List[int]]):
                 f"batch_size should be a positive integer value, but got batch_size={batch_size}"
             )
         if not isinstance(drop_last, bool):
-            raise ValueError(
-                f"drop_last should be a boolean value, but got drop_last={drop_last}"
-            )
+            raise ValueError(f"drop_last should be a boolean value, but got drop_last={drop_last}")
         self.sampler = sampler
         self.batch_size = batch_size
         self.drop_last = drop_last

--- a/harness_optimizer/datamodels.py
+++ b/harness_optimizer/datamodels.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Protocol, Union
+
 from strands import Agent
 
 SupportedAgent = Union["Agent"]
@@ -22,12 +23,10 @@ class Rollout:
 class AgentCreator(Protocol):
     """Protocol for callables that create fresh agent instances."""
 
-    def __call__(self) -> SupportedAgent:
-        ...
+    def __call__(self) -> SupportedAgent: ...
 
 
 class AgentInvoker(Protocol):
     """Protocol for callables that invoke agents and return rollouts."""
 
-    def __call__(self, agent: SupportedAgent, data_sample: dict) -> Rollout:
-        ...
+    def __call__(self, agent: SupportedAgent, data_sample: dict) -> Rollout: ...

--- a/harness_optimizer/formulas/__init__.py
+++ b/harness_optimizer/formulas/__init__.py
@@ -1,11 +1,7 @@
 """Formulas — define what to optimize."""
 
+from .context_expansion_formula import ContextExpansionFormula
 from .formula import Formula
 from .system_prompt_formula import SystemPromptFormula
-from .context_expansion_formula import ContextExpansionFormula
 
-__all__ = [
-    "Formula",
-    "SystemPromptFormula",
-    "ContextExpansionFormula"
-]
+__all__ = ["Formula", "SystemPromptFormula", "ContextExpansionFormula"]

--- a/harness_optimizer/formulas/context_expansion_formula.py
+++ b/harness_optimizer/formulas/context_expansion_formula.py
@@ -6,6 +6,7 @@ in the agent's message history.
 """
 
 import logging
+
 from strands.hooks.events import BeforeModelCallEvent
 
 from .formula import Formula
@@ -77,13 +78,13 @@ class ContextExpansionFormula(Formula):
                 if isinstance(new_content[i], dict) and new_content[i].get("type") == "text":
                     new_content[i] = {
                         **new_content[i],
-                        "text": f"{new_content[i].get('text', '')}\n\n{self.instruction}"
+                        "text": f"{new_content[i].get('text', '')}\n\n{self.instruction}",
                     }
                     break
                 elif isinstance(new_content[i], dict) and "text" in new_content[i]:
                     new_content[i] = {
                         **new_content[i],
-                        "text": f"{new_content[i].get('text', '')}\n\n{self.instruction}"
+                        "text": f"{new_content[i].get('text', '')}\n\n{self.instruction}",
                     }
                     break
         else:
@@ -94,7 +95,7 @@ class ContextExpansionFormula(Formula):
 
         modified_messages[user_message_idx] = {
             **modified_messages[user_message_idx],
-            "content": new_content
+            "content": new_content,
         }
 
         return {"messages": modified_messages}
@@ -107,4 +108,3 @@ class ContextExpansionFormula(Formula):
         """Update parameters from params dict."""
         if "instruction" in params:
             self.instruction = params["instruction"]
-

--- a/harness_optimizer/formulas/formula.py
+++ b/harness_optimizer/formulas/formula.py
@@ -8,6 +8,7 @@ through rollout-based feedback.
 
 from abc import ABC, abstractmethod
 from typing import Any
+
 from strands.hooks import HookEvent
 
 
@@ -44,7 +45,9 @@ class Formula(ABC):
                 first-class, or strings for other frameworks.
         """
         if not trigger_timings:
-            raise ValueError("trigger_timings must not be empty — a Formula must have at least one trigger timing.")
+            raise ValueError(
+                "trigger_timings must not be empty — a Formula must have at least one trigger timing."
+            )
         self.name = name
         self.trigger_timings = trigger_timings
 

--- a/harness_optimizer/formulas/system_prompt_formula.py
+++ b/harness_optimizer/formulas/system_prompt_formula.py
@@ -50,9 +50,7 @@ class SystemPromptFormula(Formula):
             logger.warning("No system prompt set, skipping processing")
             return context
 
-        logger.info(
-            f"Updating system prompt: {self.system_prompt[:50]}..."
-        )
+        logger.info(f"Updating system prompt: {self.system_prompt[:50]}...")
         return {"system_prompt": self.system_prompt}
 
     def get_tunable_params(self) -> dict:

--- a/harness_optimizer/optimizers/__init__.py
+++ b/harness_optimizer/optimizers/__init__.py
@@ -3,4 +3,9 @@
 from .optimizer import FormulaOptimizer
 from .system_prompt import BaseAgenticOptimizer, ContrastiveReflectionOptimizer, MultiAgentOptimizer
 
-__all__ = ["FormulaOptimizer", "BaseAgenticOptimizer", "ContrastiveReflectionOptimizer", "MultiAgentOptimizer"]
+__all__ = [
+    "FormulaOptimizer",
+    "BaseAgenticOptimizer",
+    "ContrastiveReflectionOptimizer",
+    "MultiAgentOptimizer",
+]

--- a/harness_optimizer/optimizers/system_prompt/base_agentic_optimizer.py
+++ b/harness_optimizer/optimizers/system_prompt/base_agentic_optimizer.py
@@ -14,10 +14,10 @@ import shutil
 import tempfile
 from typing import Optional
 
+from botocore.config import Config as BotocoreConfig
 from strands import Agent, tool
 from strands.models import BedrockModel
 from strands_tools import shell
-from botocore.config import Config as BotocoreConfig
 
 from ...formulas import Formula
 from ...utils.guardrails import ToolOutputGuardrail
@@ -128,7 +128,11 @@ class BaseAgenticOptimizer(FormulaOptimizer):
     def _create_agent(self, system_prompt: str) -> Agent:
         """Create a strands Agent with shell tool, submit tool, and output guardrail."""
         if self.boto_config:
-            override = self.boto_config if isinstance(self.boto_config, BotocoreConfig) else BotocoreConfig(**self.boto_config)
+            override = (
+                self.boto_config
+                if isinstance(self.boto_config, BotocoreConfig)
+                else BotocoreConfig(**self.boto_config)
+            )
             boto_config = self._DEFAULT_BOTO_CONFIG.merge(override)
         else:
             boto_config = self._DEFAULT_BOTO_CONFIG
@@ -271,7 +275,11 @@ class BaseAgenticOptimizer(FormulaOptimizer):
                 "data": {
                     "messages": rollout.messages,
                     "reward": reward_value,
-                    "metrics": {"reward": reward_value, "metadata": reward_obj.metadata} if reward_obj else {},
+                    "metrics": (
+                        {"reward": reward_value, "metadata": reward_obj.metadata}
+                        if reward_obj
+                        else {}
+                    ),
                     "task": rollout.data_sample,
                 },
             }
@@ -362,4 +370,3 @@ class BaseAgenticOptimizer(FormulaOptimizer):
             self._prompt_history = list(state["prompt_history"])
         if "sampled_indices" in state:
             self._sampled_indices = list(state["sampled_indices"])
-

--- a/harness_optimizer/optimizers/system_prompt/contrastive_reflection.py
+++ b/harness_optimizer/optimizers/system_prompt/contrastive_reflection.py
@@ -105,7 +105,9 @@ class ContrastiveReflectionOptimizer(BaseAgenticOptimizer):
                 self.formula.update_params(optimized_params)
                 self._prompt_history.append(optimized_params)
                 self._step_count += 1
-                summary = ", ".join(f"{k} ({len(str(v))} chars)" for k, v in optimized_params.items())
+                summary = ", ".join(
+                    f"{k} ({len(str(v))} chars)" for k, v in optimized_params.items()
+                )
                 logger.info(f"Step {self._step_count}: updated params: {summary}")
             else:
                 raise RuntimeError(

--- a/harness_optimizer/rollout_engines/__init__.py
+++ b/harness_optimizer/rollout_engines/__init__.py
@@ -1,8 +1,8 @@
 """Agent rollout engines — execute agents on data samples to produce rollouts."""
 
 from .agent_rollout_engine import AgentRolloutEngine
-from .local_engine import LocalRolloutEngine
 from .agentcore_engine import AgentCoreRolloutEngine
+from .local_engine import LocalRolloutEngine
 
 __all__ = [
     "AgentRolloutEngine",

--- a/harness_optimizer/rollout_engines/agentcore_engine.py
+++ b/harness_optimizer/rollout_engines/agentcore_engine.py
@@ -142,9 +142,7 @@ class AgentCoreRolloutEngine(AgentRolloutEngine):
             boto_config=boto_config,
         )
 
-        logger.info(
-            f"Initialized AgentCoreRolloutEngine (num_workers={num_workers})"
-        )
+        logger.info(f"Initialized AgentCoreRolloutEngine (num_workers={num_workers})")
 
     def ensure_sync_params(self) -> None:
         """Capture current formula params for the upcoming batch."""

--- a/harness_optimizer/rollout_engines/local_engine.py
+++ b/harness_optimizer/rollout_engines/local_engine.py
@@ -11,8 +11,8 @@ from typing import Callable, Iterator
 
 from ..datamodels import AgentCreator, AgentInvoker, Rollout, SupportedAgent
 from ..formulas import Formula
-from .agent_rollout_engine import AgentRolloutEngine
 from ..utils.parallel_rollout import expand_for_num_rollouts, run_parallel
+from .agent_rollout_engine import AgentRolloutEngine
 
 logger = logging.getLogger(__name__)
 

--- a/harness_optimizer/utils/__init__.py
+++ b/harness_optimizer/utils/__init__.py
@@ -1,3 +1,3 @@
 """Utility modules for Harness Optimizer."""
 
-from .templates import create_template, load_builtin_template, list_builtin_templates
+from .templates import create_template, list_builtin_templates, load_builtin_template

--- a/harness_optimizer/utils/guardrails/tool_output.py
+++ b/harness_optimizer/utils/guardrails/tool_output.py
@@ -35,7 +35,7 @@ class ToolOutputGuardrail:
             if isinstance(item, dict) and "text" in item:
                 text = item["text"]
                 if len(text) > self.max_chars:
-                    preview = text[:self.max_chars]
+                    preview = text[: self.max_chars]
                     item["text"] = (
                         f"{preview}\n\n"
                         f"[TRUNCATED: Output exceeded {self.max_chars} characters. "

--- a/harness_optimizer/utils/parallel_rollout.py
+++ b/harness_optimizer/utils/parallel_rollout.py
@@ -60,9 +60,7 @@ def run_parallel(
 
     results = [None] * len(tasks)
     with ThreadPoolExecutor(max_workers=num_workers) as executor:
-        future_to_idx = {
-            executor.submit(safe_invoke, fn, s): i for i, s in enumerate(tasks)
-        }
+        future_to_idx = {executor.submit(safe_invoke, fn, s): i for i, s in enumerate(tasks)}
         for future in as_completed(future_to_idx, timeout=3600):
             idx = future_to_idx[future]
             try:
@@ -70,9 +68,7 @@ def run_parallel(
             except Exception as e:
                 logger.error(f"Task {idx} failed: {e}")
                 results[idx] = Rollout(
-                    data_sample=tasks[idx],
-                    messages=[],
-                    metadata={"error": str(e)}
+                    data_sample=tasks[idx], messages=[], metadata={"error": str(e)}
                 )
     return results
 
@@ -91,8 +87,4 @@ def safe_invoke(fn: Callable[[dict], Rollout], data_sample: dict) -> Rollout:
         return fn(data_sample)
     except Exception as e:
         logger.error(f"Invocation failed for {data_sample}: {e}")
-        return Rollout(
-            data_sample=data_sample,
-            messages=[],
-            metadata={"error": str(e)}
-        )
+        return Rollout(data_sample=data_sample, messages=[], metadata={"error": str(e)})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=45", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "harness-optimizer"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A framework for optimizing LLM agent context through Formulas"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -39,12 +39,37 @@ dev = [
     "mypy>=0.990",
 ]
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["harness_optimizer*"]
+[tool.hatch.version]
+source = "vcs"
 
-[tool.setuptools.package-data]
-harness_optimizer = ["templates/**/*.jinja"]
+[tool.hatch.build.hooks.vcs]
+version-file = "harness_optimizer/_version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["harness_optimizer"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "harness_optimizer",
+    "tests",
+    "README.md",
+    "LICENSE",
+    "NOTICE",
+]
+
+[tool.hatch.envs.default]
+features = ["dev"]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest {args}"
+lint = [
+    "black --check harness_optimizer tests",
+    "isort --check-only harness_optimizer tests",
+]
+format = [
+    "black harness_optimizer tests",
+    "isort harness_optimizer tests",
+]
 
 [tool.black]
 line-length = 100

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -1,12 +1,12 @@
 """Unit tests for the strands agent adapter."""
 
-import pytest
 from unittest.mock import MagicMock
 
+import pytest
 from strands.hooks.events import BeforeInvocationEvent
 
-from harness_optimizer.formulas import SystemPromptFormula
 from harness_optimizer.adapters import StrandsAdapter, apply_formulas_on_strands_agent
+from harness_optimizer.formulas import SystemPromptFormula
 
 
 @pytest.fixture

--- a/tests/adapters/test_strands_adapter_integration.py
+++ b/tests/adapters/test_strands_adapter_integration.py
@@ -4,12 +4,13 @@ Requires AWS credentials; skipped otherwise.
 """
 
 import os
+
 import pytest
 from dotenv import load_dotenv
 from strands import Agent
 
-from harness_optimizer.formulas import SystemPromptFormula
 from harness_optimizer.adapters import StrandsAdapter
+from harness_optimizer.formulas import SystemPromptFormula
 
 load_dotenv()
 
@@ -23,6 +24,7 @@ class TestEndToEndWithModel:
     @pytest.fixture
     def model(self):
         from strands.models import BedrockModel
+
         return BedrockModel(
             model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
             region_name="us-west-2",

--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -1,6 +1,6 @@
 """Tests for DataLoader — verifying Dataset + Sampler integration."""
 
-from harness_optimizer.data import Dataset, DataLoader
+from harness_optimizer.data import DataLoader, Dataset
 
 
 class ListDataset(Dataset):
@@ -16,13 +16,15 @@ class ListDataset(Dataset):
 
 def test_dataloader_shuffle_with_dict_samples():
     """DataLoader batches, shuffles, and works with dict samples."""
-    ds = ListDataset([
-        {"prompt": "What is 2+3?", "answer": "5"},
-        {"prompt": "What is 10-4?", "answer": "6"},
-        {"prompt": "What is 7*8?", "answer": "56"},
-        {"prompt": "What is 100/4?", "answer": "25"},
-        {"prompt": "What is 15+27?", "answer": "42"},
-    ])
+    ds = ListDataset(
+        [
+            {"prompt": "What is 2+3?", "answer": "5"},
+            {"prompt": "What is 10-4?", "answer": "6"},
+            {"prompt": "What is 7*8?", "answer": "56"},
+            {"prompt": "What is 100/4?", "answer": "25"},
+            {"prompt": "What is 15+27?", "answer": "42"},
+        ]
+    )
     loader = DataLoader(ds, batch_size=2, shuffle=True)
     batches = list(loader)
     assert len(batches) == 3  # 2 + 2 + 1

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -1,6 +1,6 @@
 """Tests for Dataset classes."""
 
-from harness_optimizer.data import Dataset, IterableDataset, ChainDataset, Subset
+from harness_optimizer.data import ChainDataset, Dataset, IterableDataset, Subset
 
 
 class ListDataset(Dataset):

--- a/tests/formulas/test_formula.py
+++ b/tests/formulas/test_formula.py
@@ -1,7 +1,7 @@
 """Tests for the Formula base class."""
 
 import pytest
-from strands.hooks.events import BeforeInvocationEvent, AfterInvocationEvent
+from strands.hooks.events import AfterInvocationEvent, BeforeInvocationEvent
 
 from harness_optimizer.formulas import Formula
 
@@ -37,10 +37,13 @@ class TestFormulaInit:
         class MultiTiming(Formula):
             def __init__(self):
                 super().__init__("multi", [BeforeInvocationEvent, AfterInvocationEvent])
+
             def process(self, context, **kwargs):
                 return context
+
             def get_tunable_params(self):
                 return {}
+
             def update_params(self, params):
                 pass
 

--- a/tests/optimizers/test_contrastive_reflection.py
+++ b/tests/optimizers/test_contrastive_reflection.py
@@ -1,6 +1,7 @@
 """Tests for the ContrastiveReflectionOptimizer."""
 
 import os
+
 import pytest
 from dotenv import load_dotenv
 from strands.models import BedrockModel
@@ -22,12 +23,18 @@ def test_writes_rollouts_and_cleans_up():
     optimizer = ContrastiveReflectionOptimizer(
         formula,
         system_prompt_template=load_builtin_template("contrastive_reflection/system_prompt.jinja"),
-        task_message_template=load_builtin_template("contrastive_reflection/task_message_system_prompt.jinja"),
+        task_message_template=load_builtin_template(
+            "contrastive_reflection/task_message_system_prompt.jinja"
+        ),
         model_config={"model_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0"},
     )
-    optimizer.add_rollouts([
-        Rollout(data_sample={"prompt": "test"}, messages=[{"role": "user", "content": "hello"}]),
-    ])
+    optimizer.add_rollouts(
+        [
+            Rollout(
+                data_sample={"prompt": "test"}, messages=[{"role": "user", "content": "hello"}]
+            ),
+        ]
+    )
     optimizer.add_rewards([Reward(reward=1)])
 
     # Sample and write traces to temp
@@ -49,25 +56,37 @@ def test_contrastive_reflection_step():
     optimizer = ContrastiveReflectionOptimizer(
         formula,
         system_prompt_template=load_builtin_template("contrastive_reflection/system_prompt.jinja"),
-        task_message_template=load_builtin_template("contrastive_reflection/task_message_system_prompt.jinja"),
+        task_message_template=load_builtin_template(
+            "contrastive_reflection/task_message_system_prompt.jinja"
+        ),
         model_config={"model_id": "us.anthropic.claude-sonnet-4-20250514-v1:0"},
     )
 
     # Add simulated rollouts with contrasting rewards
-    optimizer.add_rollouts([
-        Rollout(
-            data_sample={"prompt": "What is 2+3?", "expected_answer": "5", "uuid": "uuid1"},
-            messages=[{"role": "user", "content": "What is 2+3?"}, {"role": "assistant", "content": "2 + 3 = 5"}]
-        ),
-        Rollout(
-            data_sample={"prompt": "What is 10-4?", "expected_answer": "6", "uuid": "uuid2"},
-            messages=[{"role": "user", "content": "What is 10-4?"}, {"role": "assistant", "content": "6"}]
-        ),
-    ])
-    optimizer.add_rewards([
-        Reward(reward=0.0, metadata={"reason": "response contains extra text"}),
-        Reward(reward=1.0, metadata={"reason": "exact match"}),
-    ])
+    optimizer.add_rollouts(
+        [
+            Rollout(
+                data_sample={"prompt": "What is 2+3?", "expected_answer": "5", "uuid": "uuid1"},
+                messages=[
+                    {"role": "user", "content": "What is 2+3?"},
+                    {"role": "assistant", "content": "2 + 3 = 5"},
+                ],
+            ),
+            Rollout(
+                data_sample={"prompt": "What is 10-4?", "expected_answer": "6", "uuid": "uuid2"},
+                messages=[
+                    {"role": "user", "content": "What is 10-4?"},
+                    {"role": "assistant", "content": "6"},
+                ],
+            ),
+        ]
+    )
+    optimizer.add_rewards(
+        [
+            Reward(reward=0.0, metadata={"reason": "response contains extra text"}),
+            Reward(reward=1.0, metadata={"reason": "exact match"}),
+        ]
+    )
 
     optimizer.step()
 

--- a/tests/optimizers/test_multi_agent.py
+++ b/tests/optimizers/test_multi_agent.py
@@ -18,9 +18,13 @@ def test_multi_agent_writes_rollouts_and_cleans_up():
         rollout_analyzer_template=load_builtin_template("multi_agent/rollout_analyzer.jinja"),
         model_config={"model_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0"},
     )
-    optimizer.add_rollouts([
-        Rollout(messages=[{"role": "user", "content": "hello"}], data_sample={"prompt": "test"}),
-    ])
+    optimizer.add_rollouts(
+        [
+            Rollout(
+                messages=[{"role": "user", "content": "hello"}], data_sample={"prompt": "test"}
+            ),
+        ]
+    )
     optimizer.add_rewards([Reward(reward=1.0)])
 
     # Sample and write traces to temp
@@ -45,6 +49,7 @@ def test_multi_agent_has_swarm_tool():
     )
 
     from strands_tools import swarm
+
     assert swarm in optimizer._get_extra_tools()
 
 

--- a/tests/optimizers/test_optimization_integration.py
+++ b/tests/optimizers/test_optimization_integration.py
@@ -9,16 +9,17 @@ Requires AWS credentials; skipped otherwise.
 
 import os
 import re
+
 import pytest
 from dotenv import load_dotenv
 from strands import Agent
 from strands.models import BedrockModel
 
+from harness_optimizer.adapters import StrandsAdapter
 from harness_optimizer.datamodels import Reward, Rollout
 from harness_optimizer.formulas import SystemPromptFormula
-from harness_optimizer.adapters import StrandsAdapter
-from harness_optimizer.rewards import RewardFunction
 from harness_optimizer.optimizers import FormulaOptimizer
+from harness_optimizer.rewards import RewardFunction
 
 load_dotenv()
 
@@ -27,6 +28,7 @@ has_aws_credentials = bool(os.environ.get("AWS_ACCESS_KEY_ID"))
 
 class ConcisenessReward(RewardFunction):
     """Returns reward 1.0 if the response exactly matches the expected answer."""
+
     def __call__(self, rollout: Rollout) -> Reward:
         response_text = rollout.metadata.get("response_text", "").strip()
         expected = rollout.data_sample.get("expected_answer", "").strip()
@@ -36,7 +38,7 @@ class ConcisenessReward(RewardFunction):
             metadata={
                 "response_text": response_text,
                 "expected_answer": expected,
-            }
+            },
         )
 
 
@@ -55,9 +57,7 @@ class LLMPromptOptimizer(FormulaOptimizer):
     def step(self):
         # Build analysis of rollouts for the LLM
         analysis = []
-        for i, (rollout, reward) in enumerate(
-            zip(self._rollouts, self._rewards)
-        ):
+        for i, (rollout, reward) in enumerate(zip(self._rollouts, self._rewards)):
             sample = rollout.data_sample
             analysis.append(
                 f"Task: {sample.get('prompt', '')}\n"
@@ -69,10 +69,10 @@ class LLMPromptOptimizer(FormulaOptimizer):
         current_prompt = self.formula.get_tunable_params().get("system_prompt", "")
         optimization_prompt = (
             f"You are optimizing a system prompt for an LLM agent.\n\n"
-            f"Current system prompt: \"{current_prompt}\"\n\n"
+            f'Current system prompt: "{current_prompt}"\n\n'
             f"Here are the agent's rollouts and their rewards:\n\n"
-            + "\n\n".join(analysis) +
-            f"\n\nAnalyze what patterns lead to high vs low rewards, "
+            + "\n\n".join(analysis)
+            + f"\n\nAnalyze what patterns lead to high vs low rewards, "
             f"and generate an improved system prompt.\n\n"
             f"Reply with ONLY the new system prompt, nothing else."
         )
@@ -124,7 +124,7 @@ class TestOptimizationWithModel:
                 rollout = Rollout(
                     data_sample=sample,
                     messages=list(agent.messages),
-                    metadata={"response_text": response_text}
+                    metadata={"response_text": response_text},
                 )
                 reward = reward_fn(rollout)
 

--- a/tests/optimizers/test_optimizer.py
+++ b/tests/optimizers/test_optimizer.py
@@ -8,6 +8,7 @@ from harness_optimizer.optimizers import FormulaOptimizer
 
 class PickBestOptimizer(FormulaOptimizer):
     """Picks the prompt hint from the highest-reward rollout."""
+
     def step(self):
         best_idx = max(range(len(self._rewards)), key=lambda i: self._rewards[i]["reward_value"])
         hint = self._rollouts[best_idx].get("data_sample", {}).get("hint", "")
@@ -39,10 +40,12 @@ def test_optimizer_accumulate_step_and_checkpoint():
     # Accumulate, step, verify formula updated (rollout contains data_sample)
     formula = SystemPromptFormula(system_prompt="original")
     optimizer = PickBestOptimizer(formula)
-    optimizer.add_rollouts([
-        {"messages": ["t1"], "data_sample": {"hint": "be brief"}},
-        {"messages": ["t2"], "data_sample": {"hint": "use examples"}},
-    ])
+    optimizer.add_rollouts(
+        [
+            {"messages": ["t1"], "data_sample": {"hint": "be brief"}},
+            {"messages": ["t2"], "data_sample": {"hint": "use examples"}},
+        ]
+    )
     optimizer.add_rewards(
         [{"reward_value": 0.2}, {"reward_value": 0.8}],
     )

--- a/tests/rollout_engines/test_agent_rollout_engine.py
+++ b/tests/rollout_engines/test_agent_rollout_engine.py
@@ -11,10 +11,13 @@ class MockFormula(Formula):
     def __init__(self, prompt="initial"):
         super().__init__("mock", ["before_invocation"])
         self.prompt = prompt
+
     def process(self, context, **kwargs):
         return {"system_prompt": self.prompt}
+
     def get_tunable_params(self):
         return {"system_prompt": self.prompt}
+
     def update_params(self, params):
         self.prompt = params.get("system_prompt", self.prompt)
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,10 +1,10 @@
 """Tests for the Trainer — full loop with mock components."""
 
-from harness_optimizer.data import Dataset, DataLoader
+from harness_optimizer.data import DataLoader, Dataset
 from harness_optimizer.datamodels import Reward, Rollout
 from harness_optimizer.formulas import Formula
-from harness_optimizer.rewards import RewardFunction
 from harness_optimizer.optimizers import FormulaOptimizer
+from harness_optimizer.rewards import RewardFunction
 from harness_optimizer.rollout_engines import AgentRolloutEngine
 from harness_optimizer.trainer import Trainer
 
@@ -52,8 +52,10 @@ class MockOptimizer(FormulaOptimizer):
 class ListDataset(Dataset):
     def __init__(self, data):
         self.data = data
+
     def __getitem__(self, index):
         return self.data[index]
+
     def __len__(self):
         return len(self.data)
 


### PR DESCRIPTION
## Summary

Makes the repository publishable to PyPI, matching the `strands-labs/robots` release setup.

### Changes

**Packaging (`pyproject.toml`)**
- Migrate build backend `setuptools` → `hatchling` + `hatch-vcs`
- Version is now **dynamic** (`dynamic = ["version"]`), derived from git tags via `hatch-vcs`
- Generated `_version.py` is gitignored; `__init__.py` reads `__version__` from it with a dev fallback
- Add hatch envs with `test`, `lint`, and `format` scripts

**CI/CD (`.github/workflows/`)**
- `test-lint.yml` — reusable workflow: `black --check`, `isort --check`, `pytest` (adapted from robots; dropped MuJoCo/OpenGL system deps which don't apply here)
- `pypi-publish-on-release.yml` — on GitHub Release: lint → build → publish to PyPI via OIDC trusted publishing. PyPI project name set to `harness-optimizer`

**Formatting**
- Applied `black` + `isort` across the codebase (separate commit) so the lint gate passes

### Verification
- `hatch version` ✓ (resolves to clean `X.Y.Z` on tagged releases)
- `hatch build` ✓ — sdist + wheel, Jinja templates bundled
- `twine check` ✓ PASSED
- `hatch run lint` ✓ (black + isort clean)

### Follow-up required before first publish
Configure a **PyPI trusted publisher**: project `harness-optimizer`, environment `pypi`, workflow `pypi-publish-on-release.yml`. Then publishing a GitHub Release triggers the pipeline.

> Note: commits are split — one formatting-only commit and one packaging/workflow commit — for easier review.