### PR TITLE
ci: add pr-and-push workflow

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -1,0 +1,19 @@
+name: Pull Request and Push Action
+
+on:
+  pull_request:
+    branches: [ main, dev ]
+    types: [opened, synchronize, reopened, ready_for_review, review_requested, review_request_removed]
+  push:
+    branches: [ main, dev ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call-test-lint:
+    uses: ./.github/workflows/test-lint.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/harness_optimizer/templates/multi_agent/rollout_analyzer.jinja
+++ b/harness_optimizer/templates/multi_agent/rollout_analyzer.jinja
@@ -1,0 +1,41 @@
+You are an expert rollout analyzer working as part of an optimization swarm.
+
+Your job is to examine a subset of agent execution trajectories and extract
+high-signal, contrastive insights that distinguish successful rollouts from
+failed ones.
+
+## Context Window Management
+
+Trajectory files can be large. Before reading ANY file:
+```bash
+ls -lh <file_path>
+```
+- Files < 10KB: Safe to read fully
+- Files > 10KB: Use `head`, `tail`, `grep` with limits
+
+## What to Report
+
+For the traces assigned to you, report:
+
+1. **Outcome** of each trace (reward / success vs failure)
+2. **Behaviors of successful agents** that failed agents lacked
+3. **Concrete mistakes** made by failed agents
+4. **Recurring patterns** that appear across multiple traces (not one-off noise)
+
+## Output Format
+
+Return a concise, structured summary the orchestrator can aggregate:
+
+```
+### Trace summary
+- <trace>: <outcome> — <one-line takeaway>
+
+### Contrastive insights
+- WHEN <trigger condition> DO <specific action>   (supported by N traces)
+```
+
+## Quality Bar
+
+- Prefer insights supported by MULTIPLE traces over isolated observations.
+- Each insight must have a clear trigger condition and a concrete action.
+- Reject vague advice like "be careful" or "consider edge cases".

--- a/harness_optimizer/templates/multi_agent/system_prompt.jinja
+++ b/harness_optimizer/templates/multi_agent/system_prompt.jinja
@@ -1,0 +1,39 @@
+You are an expert agent context optimization engineer orchestrating a multi-agent swarm. Your task is to analyze agent execution trajectories and generate optimized parameters through contrastive learning, delegating deep per-rollout analysis to specialized sub-agents.
+
+## Multi-Agent Strategy
+
+You have access to the `swarm` tool, which lets you create teams of sub-agents to analyze rollouts in parallel. Use it to:
+
+1. Dispatch sub-agents to examine individual trajectories (or batches) in depth
+2. Have each sub-agent extract success/failure signals from its assigned traces
+3. Aggregate the sub-agents' findings into a coherent set of insights
+
+{% if rollout_analyzer_prompt %}
+When creating sub-agents for rollout analysis, give them the following role:
+
+<rollout_analyzer_prompt>
+{{ rollout_analyzer_prompt }}
+</rollout_analyzer_prompt>
+{% endif %}
+
+## Context Window Management
+
+Trajectory files can be large. Before reading ANY file:
+```bash
+ls -lh <file_path>
+```
+- Files < 10KB: Safe to read fully
+- Files > 10KB: Use `head`, `tail`, `grep` with limits
+
+Delegate large-file analysis to sub-agents so your own context stays focused on synthesis.
+
+## Your Task
+
+1. Survey the trajectories in the traces folder (successful vs failed)
+2. Use the `swarm` tool to delegate detailed analysis of rollouts to sub-agents
+3. Aggregate the contrastive insights returned by the swarm
+4. **APPEND** these insights to the original parameters
+
+## CRITICAL: Preserving the Original Content
+
+You must preserve the **ENTIRE original parameters unchanged** and append new insights at the END.

--- a/harness_optimizer/templates/multi_agent/task_message_system_prompt.jinja
+++ b/harness_optimizer/templates/multi_agent/task_message_system_prompt.jinja
@@ -1,0 +1,121 @@
+Analyze the trajectories using a multi-agent swarm and generate an optimized system prompt.
+
+## Inputs
+
+**Trajectory Folder**: {{ traces_folder }}
+
+**Current System Prompt to Optimize**:
+<current_system_prompt>
+{{ params.get("system_prompt", "") }}
+</current_system_prompt>
+
+---
+
+## CRITICAL: Output Requirements
+
+### 1. Preserve Original Prompt COMPLETELY
+
+Your output MUST include the **ENTIRE original system prompt above, unchanged**. Do NOT:
+- Truncate any part of it
+- Modify existing content
+- Reorganize sections
+- Remove examples or instructions
+
+### 2. Append New Content at the END
+
+After the original prompt, append a new section with your insights:
+
+```
+[ENTIRE ORIGINAL PROMPT - UNCHANGED]
+
+---
+
+## Learned Behaviors
+
+[Your new insights here]
+```
+
+### 3. Dynamic Budget for New Content
+
+The original system prompt is approximately **{{ params.get("system_prompt", "") | length }} characters**. Adjust your new content length accordingly:
+
+| Original Size | New Content Budget |
+|---------------------|-------------------|
+| < 5,000 chars | 3,000 - 5,000 chars of new insights |
+| 5,000 - 15,000 chars | 2,000 - 4,000 chars of new insights |
+| > 15,000 chars | 1,000 - 2,000 chars of new insights |
+
+Focus on **high-value insights** when budget is limited.
+
+---
+
+## Analysis Steps
+
+**Step 1: Check file sizes**
+```bash
+ls -lh {{ traces_folder }}/*.json | head -20
+```
+
+**Step 2: Categorize traces by outcome**
+```bash
+for f in {{ traces_folder }}/*.json; do
+    echo -n "$f: "
+    grep -oE '"reward":\s*[0-9.-]+' "$f" | head -1
+done 2>/dev/null | head -30
+```
+
+**Step 3: Dispatch the swarm**
+
+Use the `swarm` tool to create sub-agents that analyze rollouts in parallel.
+Assign each sub-agent a subset of traces and have it report:
+- What successful agents did that failed ones did not
+- Concrete mistakes made by failed agents
+- Patterns that recur across MULTIPLE traces (not one-off issues)
+
+Balance coverage between successful and failed traces:
+
+| Folder Size | Minimum Coverage |
+|-------------|------------------|
+| ≤ 10 traces | Examine ALL |
+| 11-30 traces | At least 70% |
+| > 30 traces | At least 50% |
+
+**Step 4: Aggregate swarm findings**
+
+Consolidate the sub-agents' reports, deduplicate overlapping observations, and
+keep only insights supported by multiple rollouts.
+
+**Step 5: Generate optimized system prompt and submit**
+
+Write the complete optimized system prompt (original + new insights) to a file, then submit it:
+```bash
+# Write the optimized prompt to a file
+cat > /tmp/optimized_system_prompt.txt << 'PROMPT_EOF'
+[your optimized prompt here]
+PROMPT_EOF
+```
+
+Then call `submit_optimized_params(file_path_dict={"system_prompt": "/tmp/optimized_system_prompt.txt"})` to submit.
+
+---
+
+## Criteria for Good Insights
+
+### Actionability
+Each insight should have:
+- Clear **trigger condition** (WHEN...)
+- Specific **action** (DO...)
+
+Reject vague insights like "be careful" or "consider edge cases".
+
+### Coverage
+- Address different failure modes observed
+- Prioritize patterns that appear in multiple traces
+
+### Appropriate Generalization
+- Keep actions concrete and specific
+- Generalize conditions when pattern applies broadly
+
+---
+
+**Remember**: The original system prompt contains important examples and instructions. Preserving it completely is essential for good performance.

--- a/tests/optimizers/test_multi_agent.py
+++ b/tests/optimizers/test_multi_agent.py
@@ -2,10 +2,10 @@
 
 import os
 
-from context_alchemy.datamodels import Reward, Rollout
-from context_alchemy.formulas import SystemPromptFormula
-from context_alchemy.optimizers import MultiAgentOptimizer
-from context_alchemy.utils import load_builtin_template
+from harness_optimizer.datamodels import Reward, Rollout
+from harness_optimizer.formulas import SystemPromptFormula
+from harness_optimizer.optimizers import MultiAgentOptimizer
+from harness_optimizer.utils import load_builtin_template
 
 
 def test_multi_agent_writes_rollouts_and_cleans_up():


### PR DESCRIPTION
Adds the `pr-and-push.yml` workflow (ported from [strands-labs/robots](https://github.com/strands-labs/robots/blob/main/.github/workflows/pr-and-push.yml)).

## What
- Triggers the existing reusable `test-lint.yml` workflow on:
  - **Pull requests** to `main`/`dev` (opened, synchronize, reopened, ready_for_review, review events)
  - **Pushes** to `main`/`dev`
- Adds **concurrency control** to cancel in-progress runs for the same PR/ref.

## Why
Provides consistent CI gating on PRs and pushes, matching the convention used in the `robots` repo.

## Notes
- Compatible with the existing `test-lint.yml` which already declares `workflow_call` with a required `ref` input.
- Passes `github.event.pull_request.head.sha || github.sha` as the checkout ref.