### PR TITLE
Rename PyPI package to strands-harness-optimizer

### DIFF
--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -66,7 +66,7 @@ jobs:
 
     environment:
       name: pypi
-      url: https://pypi.org/p/harness-optimizer
+      url: https://pypi.org/p/strands-harness-optimizer
     permissions:
       id-token: write
 

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -17,7 +17,7 @@ Harness Optimizer provides a framework for defining, attaching, and optimizing c
 ## Installation
 
 ```bash
-pip install harness-optimizer
+pip install strands-harness-optimizer
 ```
 
 ## Quick Example

--- a/examples/agent_with_context_expansion_formula.py
+++ b/examples/agent_with_context_expansion_formula.py
@@ -7,7 +7,7 @@ This example demonstrates:
 4. Updating formula parameters (simulating what an optimizer would do)
 
 Requirements:
-    pip install harness-optimizer
+    pip install strands-harness-optimizer
     AWS credentials configured for Bedrock access
 """
 

--- a/examples/agent_with_system_prompt_formula.py
+++ b/examples/agent_with_system_prompt_formula.py
@@ -7,7 +7,7 @@ This example demonstrates:
 4. Updating formula parameters (simulating what an optimizer would do)
 
 Requirements:
-    pip install harness-optimizer
+    pip install strands-harness-optimizer
     AWS credentials configured for Bedrock access
 """
 

--- a/examples/gsm8k_optimization.py
+++ b/examples/gsm8k_optimization.py
@@ -9,7 +9,7 @@ Demonstrates the full optimization loop:
 6. System prompt is updated with learned insights
 
 Requirements:
-    pip install harness-optimizer datasets
+    pip install strands-harness-optimizer datasets
     AWS credentials configured for Bedrock access
 """
 

--- a/examples/gsm8k_trainer.py
+++ b/examples/gsm8k_trainer.py
@@ -11,7 +11,7 @@ The Trainer handles:
 - Calling optimizer.step() and zero() per epoch
 
 Requirements:
-    pip install harness-optimizer datasets
+    pip install strands-harness-optimizer datasets
     AWS credentials configured for Bedrock access
 """
 

--- a/examples/trainer_with_callable_engine.py
+++ b/examples/trainer_with_callable_engine.py
@@ -8,7 +8,7 @@ Demonstrates the full end-to-end flow using the Trainer class:
 5. Evaluate on a held-out test set
 
 Requirements:
-    pip install harness-optimizer
+    pip install strands-harness-optimizer
     AWS credentials configured for Bedrock access
 """
 


### PR DESCRIPTION
## Summary

Updates the PyPI package name from `harness-optimizer` to `strands-harness-optimizer` across install instructions and the release workflow.

## Changes

- **`.github/workflows/pypi-publish-on-release.yml`**: Update PyPI project URL to `strands-harness-optimizer`
- **`docs/src/content/docs/index.md`**: Update `pip install` instruction
- **`examples/*.py`** (5 files): Update `pip install` requirements in docstrings

7 files changed, 7 insertions(+), 7 deletions(-).