### PR TITLE
Add SkillFormula and a skill-optimization example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ Dockerfile
 
 # hatch-vcs generated
 strands_harness_optimizer/_version.py
+
+# Example output (optimized skills written by examples/skill_optimizer.py)
+optimized_skills/

--- a/examples/skill_optimization.py
+++ b/examples/skill_optimization.py
@@ -1,0 +1,239 @@
+"""Example: Optimize a Strands Agent *Skill* on GSM8K.
+
+Strands Agent Skills (https://strandsagents.com/docs/user-guide/concepts/plugins/skills/)
+are modular instruction packages loaded via the ``AgentSkills`` plugin using
+progressive disclosure: a skill's ``name`` + ``description`` are injected into the
+system prompt, and its full ``instructions`` load on demand when the agent activates
+the skill via the ``skills`` tool.
+
+Both the ``description`` (the discovery hook) and the ``instructions`` (the payload)
+are optimizable context. This example uses the built-in ``SkillFormula`` to make a
+``Skill``'s text a *tunable parameter*, then drives the automated ``Trainer`` loop
+(``LocalRolloutEngine`` + ``ContrastiveReflectionOptimizer``) to rewrite the skill's
+instructions from success/failure patterns on GSM8K.
+
+The Formula is the single interface the optimizer talks to, and the control flow is
+explicit: optimizer -> Formula.update_params() (mutates the Skill) -> the adapter
+calls Formula.process() each invocation and pushes the returned skill into the
+AgentSkills plugin via set_available_skills(). The formula never touches the agent's
+system prompt, and correctness does not depend on the plugin and formula sharing the
+same Skill object.
+
+Compare with:
+- gsm8k_optimization.py — optimizes a SystemPromptFormula (manual loop)
+- gsm8k_trainer.py       — optimizes a SystemPromptFormula (Trainer loop)
+
+Requirements:
+    pip install strands-harness-optimizer datasets
+    A Strands version that ships the AgentSkills plugin (from strands import AgentSkills, Skill)
+    AWS credentials configured for Bedrock access
+"""
+
+import re
+
+try:
+    from datasets import load_dataset
+except ImportError:
+    raise ImportError(
+        "This example requires the 'datasets' package. "
+        "Install it with: pip install datasets"
+    )
+
+from strands import Agent, AgentSkills, Skill
+from strands.models import BedrockModel
+from strands_tools import shell
+
+from strands_harness_optimizer.data import DataLoader
+from strands_harness_optimizer.datamodels import Reward, Rollout
+from strands_harness_optimizer.formulas import SkillFormula
+from strands_harness_optimizer.adapters import apply_formulas_on_strands_agent
+from strands_harness_optimizer.rewards import RewardFunction
+from strands_harness_optimizer.optimizers import ContrastiveReflectionOptimizer
+from strands_harness_optimizer.rollout_engines import LocalRolloutEngine
+from strands_harness_optimizer.trainer import Trainer
+from strands_harness_optimizer.utils import load_builtin_template
+
+
+# --- Reward function: extract final number and compare ---
+
+class GSM8KReward(RewardFunction):
+    """Reward 1.0 if the agent's final number matches the expected answer."""
+
+    def __call__(self, rollout: Rollout) -> Reward:
+        response_text = rollout.metadata.get("response_text", "")
+        expected = rollout.data_sample.get("expected_answer", "")
+
+        predicted = self._extract_final_number(response_text)
+        correct = predicted is not None and predicted == expected
+
+        return Reward(
+            reward=1.0 if correct else 0.0,
+            metadata={"predicted": predicted, "expected": expected},
+        )
+
+    def _extract_final_number(self, text: str) -> str | None:
+        numbers = re.findall(r'-?\d[\d,]*\.?\d*', text.replace(",", ""))
+        if not numbers:
+            return None
+        # Normalize a trailing decimal point / zeros (e.g. "460." -> "460",
+        # "460.0" -> "460") so formatting quirks don't cause false negatives.
+        last = numbers[-1].rstrip(".")
+        if "." in last:
+            last = last.rstrip("0").rstrip(".")
+        return last
+
+
+# --- Helpers ---
+
+def parse_gsm8k_answer(answer_text: str) -> str:
+    """Extract the final answer number from GSM8K format (#### <number>)."""
+    match = re.search(r'####\s*(-?\d[\d,]*\.?\d*)', answer_text)
+    return match.group(1).replace(",", "") if match else ""
+
+
+def prepare_gsm8k(split: str):
+    """Load GSM8K and extract question + expected_answer."""
+    ds = load_dataset("openai/gsm8k", "main", split=split)
+    return [
+        {"question": row["question"], "expected_answer": parse_gsm8k_answer(row["answer"])}
+        for row in ds
+    ]
+
+
+def extract_response_text(response) -> str:
+    """Best-effort extraction of the agent's final text response."""
+    try:
+        return response.message["content"][0]["text"]
+    except Exception:
+        return str(response)
+
+
+def main():
+    # --- Load GSM8K ---
+    print("Loading GSM8K dataset...")
+    train_data = prepare_gsm8k("test[:15]")
+    test_data = prepare_gsm8k("test[15:20]")
+    train_loader = DataLoader(train_data, batch_size=15)
+    print(f"Train: {len(train_data)} problems, Test: {len(test_data)} problems")
+
+    # --- The Skill we will optimize ---
+    # Start deliberately thin: the optimizer will grow these instructions from
+    # observed success/failure patterns.
+    math_skill = Skill(
+        name="math-solver",
+        description="Solve arithmetic word problems and report a single final number.",
+        instructions=(
+            "Solve the math word problem. Show your reasoning and end with the "
+            "final numeric answer on the last line."
+        ),
+    )
+
+    # Wrap the skill so its instructions are a tunable parameter.
+    formula = SkillFormula(math_skill, tune_description=False, tune_instructions=True)
+
+    # --- Agent setup ---
+    model = BedrockModel(
+        model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        region_name="us-west-2",
+    )
+
+    # The AgentSkills plugin injects skill metadata and exposes the `skills` tool.
+    # The adapter re-syncs the formula's skill into this plugin on every
+    # invocation via set_available_skills(), so optimizer updates take effect
+    # regardless of whether the plugin initially shared the same Skill object.
+    skills_plugin = AgentSkills(skills=[math_skill])
+
+    def create_agent():
+        agent = Agent(
+            model=model,
+            system_prompt=(
+                "You are a math assistant. For every arithmetic word problem, "
+                "activate the `math-solver` skill and follow its instructions. "
+                "You may use the shell tool as a calculator."
+            ),
+            plugins=[skills_plugin],
+            tools=[shell],
+            callback_handler=None,
+        )
+        # Attach the formula so the harness treats the skill's text as tunable.
+        apply_formulas_on_strands_agent(agent, [formula])
+        return agent
+
+    def invoke_agent(agent, data_sample) -> Rollout:
+        agent.messages.clear()
+        try:
+            response = agent(data_sample["question"])
+            response_text = extract_response_text(response)
+        except Exception as e:
+            response_text = f"Error: {e}"
+        return Rollout(
+            data_sample=data_sample,
+            messages=list(agent.messages),
+            metadata={"response_text": response_text},
+        )
+
+    reward_fn = GSM8KReward()
+
+    # LocalRolloutEngine manages an agent pool and calls invoke_agent per sample.
+    engine = LocalRolloutEngine(
+        formula=formula,
+        agent_creator=create_agent,
+        agent_invoker=invoke_agent,
+    )
+
+    # The built-in contrastive_reflection templates are param-agnostic: they loop
+    # over whatever tunable params the formula exposes (here, the skill's
+    # "instructions") and submit each back under its original key. The same
+    # optimizer + templates work for SystemPromptFormula, SkillFormula, etc.
+    optimizer = ContrastiveReflectionOptimizer(
+        formula,
+        system_prompt_template=load_builtin_template("contrastive_reflection/system_prompt.jinja"),
+        task_message_template=load_builtin_template(
+            "contrastive_reflection/task_message_system_prompt.jinja"
+        ),
+        model_config={"model_id": "us.anthropic.claude-sonnet-4-20250514-v1:0"},
+        n_sample_traces=-1,
+    )
+
+    # --- Automated training loop ---
+    # The Trainer iterates the DataLoader, generates rollouts via the engine,
+    # scores them with reward_fn, and calls optimizer.step()/zero() per epoch —
+    # each step rewrites the skill's instructions in place.
+    trainer = Trainer(
+        formula=formula,
+        optimizer=optimizer,
+        reward_fn=reward_fn,
+        engine=engine,
+        dataloader=train_loader,
+        n_epochs=3,
+    )
+
+    print("\n=== Training the skill with Trainer ===")
+    print(f"Initial instructions: {formula.get_tunable_params()['instructions'][:100]}...")
+    stats = trainer.fit()
+    for s in stats:
+        print(f"  Epoch {s['epoch']}: avg_reward = {s['avg_reward']:.2f}")
+
+    # --- Test evaluation with the optimized skill ---
+    print(f"\n{'='*60}")
+    print("Test Evaluation (with optimized skill)")
+    print(f"{'='*60}")
+
+    test_agent = create_agent()
+    test_rewards = []
+    for i, sample in enumerate(test_data):
+        rollout = invoke_agent(test_agent, sample)
+        reward = reward_fn(rollout)
+        test_rewards.append(reward.reward)
+
+        status = "correct" if reward.reward == 1.0 else "wrong"
+        print(f"  [{i+1}/{len(test_data)}] {status} "
+              f"(predicted={reward.metadata['predicted']}, expected={reward.metadata['expected']})")
+
+    test_acc = sum(test_rewards) / len(test_rewards)
+    print(f"\nTest accuracy: {test_acc:.0%}")
+    print(f"\nFinal optimized skill instructions:\n{formula.get_tunable_params()['instructions']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/skill_optimizer.py
+++ b/examples/skill_optimizer.py
@@ -1,0 +1,361 @@
+"""Reference example: write your own LLM-driven optimizer (a custom BaseAgenticOptimizer).
+
+This is a template for teams adding a NEW *LLM-driven* optimization algorithm — the
+"Path B" extension point. Instead of hand-coding an update rule, you inherit a Bedrock
+reflection agent that reads the rollout traces and rewrites the Formula's params itself.
+
+``BaseAgenticOptimizer`` gives you, for free, all the reusable helpers:
+  - a Bedrock agent with the `shell` tool and a `submit_optimized_params` tool
+    (``_create_agent``), plus a ``_get_extra_tools()`` hook to add your own
+  - stratified trace sampling (``_sample_traces``), temp-folder trace writing
+    (``_write_traces_to_temp`` / ``_cleanup_temp``), an output guardrail, checkpointing
+
+You supply ``step()`` — composing those helpers into your algorithm. The canonical flow
+(sample → write traces → reflect → read submitted params → update formula → cleanup) is
+shown below and is worth copying verbatim; the interesting variation is what you override
+around it. Here we override ``_get_extra_tools()`` to give the reflection agent an
+**LLM-as-judge** tool: before submitting, the agent can call ``judge_instructions`` to
+score a candidate rewrite (0–1, with a critique) and iterate. This is the same
+``_get_extra_tools()`` hook ``MultiAgentOptimizer`` uses to add ``swarm`` — a good pattern
+for any tool-augmented reflection (a scorer/judge, retrieval, code exec, …).
+
+The reflection prompt templates and submit protocol are reused from the built-in
+contrastive_reflection setup, which is param-agnostic and therefore works unchanged on a
+``SkillFormula`` (it optimizes the skill's ``instructions``).
+
+After training, the optimized skill is written back to ``optimized_skills/<name>/SKILL.md``
+so the update persists (training only mutates the in-memory Skill); it reloads via
+``Skill.from_file(...)``.
+
+Compare with:
+- skill_optimization.py — same task, but with the stock ContrastiveReflectionOptimizer
+- gsm8k_trainer.py       — the standard Trainer loop with a SystemPromptFormula
+
+If your algorithm is programmatic (no LLM), subclass ``FormulaOptimizer`` directly and
+implement ``step()`` instead — see the "Path A" notes in the extending guide.
+
+Requirements:
+    pip install strands-harness-optimizer datasets
+    A Strands version that ships the AgentSkills plugin (from strands import AgentSkills, Skill)
+    AWS credentials configured for Bedrock access
+"""
+
+import os
+import re
+
+try:
+    from datasets import load_dataset
+except ImportError:
+    raise ImportError(
+        "This example requires the 'datasets' package. "
+        "Install it with: pip install datasets"
+    )
+
+from strands import Agent, AgentSkills, Skill, tool
+from strands.models import BedrockModel
+from strands_tools import shell
+
+from strands_harness_optimizer.data import DataLoader
+from strands_harness_optimizer.datamodels import Reward, Rollout
+from strands_harness_optimizer.formulas import SkillFormula
+from strands_harness_optimizer.adapters import apply_formulas_on_strands_agent
+from strands_harness_optimizer.optimizers import BaseAgenticOptimizer
+from strands_harness_optimizer.rewards import RewardFunction
+from strands_harness_optimizer.rollout_engines import LocalRolloutEngine
+from strands_harness_optimizer.trainer import Trainer
+from strands_harness_optimizer.utils import load_builtin_template
+
+
+# ---------------------------------------------------------------------------
+# THE PART TO STUDY: a custom LLM-driven optimizer.
+# ---------------------------------------------------------------------------
+
+class LLMJReferenceSkillOptimizer(BaseAgenticOptimizer):
+    """Reference skill optimizer: a BaseAgenticOptimizer whose reflection agent has an
+    LLM-as-judge (LLMJ) tool.
+
+    ``step()`` composes the inherited helpers into the canonical reflection flow
+    (sample traces → write to a temp folder → run the Bedrock agent → read the params
+    it submits via ``submit_optimized_params`` → ``formula.update_params(...)`` →
+    cleanup in a ``finally``). The two customizations that make this a *new* optimizer:
+
+    1. ``_get_extra_tools()`` — add a ``judge_instructions`` tool: a lightweight
+       LLM-as-judge the reflection agent can call to score a candidate rewrite (0–1,
+       with a critique) before submitting, so it can iterate toward a higher-scoring
+       version. This is the same hook ``MultiAgentOptimizer`` uses to add ``swarm``.
+    2. ``_run_reflection()`` — render the templates and run the (judge-equipped) agent.
+
+    Everything else — the submit protocol, guardrail, sampling, checkpointing — is
+    inherited unchanged.
+
+    Args:
+        formula: The Formula whose params will be optimized (any Formula works).
+        system_prompt_template / task_message_template: Jinja templates for the
+            reflection agent. The built-in param-agnostic contrastive_reflection
+            templates work as-is; pass your own to change the reflection strategy.
+        **kwargs: Forwarded to BaseAgenticOptimizer (model_config, region_name,
+            n_sample_traces, stratified_sampling, success_threshold, ...).
+    """
+
+    def __init__(self, formula, system_prompt_template, task_message_template, **kwargs):
+        super().__init__(formula, **kwargs)
+        # create_template accepts str or Template; store rendered-ready templates.
+        from strands_harness_optimizer.utils.templates import create_template
+
+        self._system_prompt_template = (
+            create_template(system_prompt_template)
+            if isinstance(system_prompt_template, str)
+            else system_prompt_template
+        )
+        self._task_message_template = (
+            create_template(task_message_template)
+            if isinstance(task_message_template, str)
+            else task_message_template
+        )
+
+    def step(self) -> None:
+        """The reflection loop, composed from inherited helpers.
+
+        This is the canonical BaseAgenticOptimizer flow — copy it verbatim and
+        customize the hooks (``_run_reflection`` / ``_get_extra_tools``) around it.
+        """
+        if not self._rollouts:  # always handle the empty buffer
+            return
+        try:
+            indices = self._sample_traces()               # stratified by reward
+            traces_folder = self._write_traces_to_temp(indices)
+            params = self.formula.get_tunable_params()     # what to optimize
+            self._run_reflection(traces_folder, params)    # run the reflection agent
+            optimized = self._get_submitted_params()       # what it submitted
+            if optimized:
+                self.formula.update_params(optimized)
+            else:
+                raise RuntimeError(
+                    "Reflection agent did not call submit_optimized_params."
+                )
+        finally:
+            self._cleanup_temp()                           # never leak temp dirs
+
+    def _get_extra_tools(self) -> list:
+        """Give the reflection agent an LLM-as-judge tool (on top of shell + submit).
+
+        The tool spins up a small Bedrock judge agent that scores a candidate
+        instruction rewrite. It reuses this optimizer's ``model_config`` /
+        ``region_name`` so no extra configuration is needed. Returning it here is all
+        it takes for the reflection agent to be able to call it.
+        """
+        model_config = self.model_config
+        region_name = self.region_name
+
+        @tool
+        def judge_instructions(candidate: str) -> str:
+            """Score a candidate skill-instruction rewrite for quality.
+
+            Args:
+                candidate: The proposed instruction text to evaluate.
+
+            Returns:
+                A line like "score=0.8 | <one-sentence critique>".
+            """
+            judge = Agent(
+                model=BedrockModel(region_name=region_name, **model_config),
+                system_prompt=(
+                    "You are a strict rubric-based judge of agent *instructions* for a "
+                    "math word-problem solver. Reply with ONLY one line: "
+                    "'score=<0..1> | <one-sentence critique>'. Reward instructions that "
+                    "are specific and actionable (clear final-answer formatting, "
+                    "step-by-step guidance) and penalize vague or contradictory ones."
+                ),
+                callback_handler=None,
+            )
+            return extract_response_text(judge(f"Instructions to score:\n{candidate}"))
+
+        return [judge_instructions]
+
+    def _run_reflection(self, traces_folder: str, params: dict) -> None:
+        """Render the templates and run the (judge-equipped) reflection agent.
+
+        Mirrors ContrastiveReflectionOptimizer._run_reflection — the base ``step()``
+        calls this after writing traces and before reading submitted params.
+        """
+        import os
+
+        template_vars = {"traces_folder": os.path.abspath(traces_folder), "params": params}
+        system_prompt = self._system_prompt_template.render(**template_vars)
+        task_message = self._task_message_template.render(**template_vars)
+
+        agent = self._create_agent(system_prompt)  # gets shell + submit + judge_instructions
+        agent(task_message)
+
+
+# ---------------------------------------------------------------------------
+# Standard harness (task, reward, agent) — see skill_optimization.py for detail.
+# ---------------------------------------------------------------------------
+
+class GSM8KReward(RewardFunction):
+    """Reward 1.0 if the agent's final number matches the expected answer."""
+
+    def __call__(self, rollout: Rollout) -> Reward:
+        response_text = rollout.metadata.get("response_text", "")
+        expected = rollout.data_sample.get("expected_answer", "")
+        predicted = self._extract_final_number(response_text)
+        return Reward(
+            reward=1.0 if predicted is not None and predicted == expected else 0.0,
+            metadata={"predicted": predicted, "expected": expected},
+        )
+
+    def _extract_final_number(self, text: str) -> str | None:
+        numbers = re.findall(r'-?\d[\d,]*\.?\d*', text.replace(",", ""))
+        if not numbers:
+            return None
+        last = numbers[-1].rstrip(".")
+        return last.rstrip("0").rstrip(".") if "." in last else last
+
+
+def parse_gsm8k_answer(answer_text: str) -> str:
+    match = re.search(r'####\s*(-?\d[\d,]*\.?\d*)', answer_text)
+    return match.group(1).replace(",", "") if match else ""
+
+
+def prepare_gsm8k(split: str):
+    ds = load_dataset("openai/gsm8k", "main", split=split)
+    return [
+        {"question": row["question"], "expected_answer": parse_gsm8k_answer(row["answer"])}
+        for row in ds
+    ]
+
+
+def extract_response_text(response) -> str:
+    try:
+        return response.message["content"][0]["text"]
+    except Exception:
+        return str(response)
+
+
+def save_skill(skill: Skill, directory: str) -> str:
+    """Persist a Skill to ``<directory>/SKILL.md`` (frontmatter + instructions).
+
+    Training only mutates the in-memory Skill; ``Skill`` has loaders
+    (``from_file``/``from_content``) but no serializer, so we write the canonical
+    SKILL.md ourselves. The result reloads via ``Skill.from_file(directory)``.
+    """
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.join(directory, "SKILL.md")
+    content = (
+        "---\n"
+        f"name: {skill.name}\n"
+        f"description: {skill.description}\n"
+        "---\n\n"
+        f"{skill.instructions}\n"
+    )
+    with open(path, "w") as f:
+        f.write(content)
+    return path
+
+
+def main():
+    print("Loading GSM8K dataset...")
+    train_data = prepare_gsm8k("test[:10]")
+    test_data = prepare_gsm8k("test[10:15]")
+    train_loader = DataLoader(train_data, batch_size=10)
+    print(f"Train: {len(train_data)} problems, Test: {len(test_data)} problems")
+
+    # The Skill we optimize (its instructions are the tunable param).
+    math_skill = Skill(
+        name="math-solver",
+        description="Solve arithmetic word problems and report a single final number.",
+        instructions="Solve the math word problem and end with the final numeric answer.",
+    )
+    formula = SkillFormula(math_skill)
+
+    model = BedrockModel(
+        model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        region_name="us-west-2",
+    )
+    skills_plugin = AgentSkills(skills=[math_skill])
+
+    def create_agent():
+        agent = Agent(
+            model=model,
+            system_prompt=(
+                "You are a math assistant. Activate the `math-solver` skill and follow "
+                "its instructions. You may use the shell tool as a calculator."
+            ),
+            plugins=[skills_plugin],
+            tools=[shell],
+            callback_handler=None,
+        )
+        apply_formulas_on_strands_agent(agent, [formula])
+        return agent
+
+    def invoke_agent(agent, data_sample) -> Rollout:
+        agent.messages.clear()
+        try:
+            response_text = extract_response_text(agent(data_sample["question"]))
+        except Exception as e:
+            response_text = f"Error: {e}"
+        return Rollout(
+            data_sample=data_sample,
+            messages=list(agent.messages),
+            metadata={"response_text": response_text},
+        )
+
+    engine = LocalRolloutEngine(
+        formula=formula, agent_creator=create_agent, agent_invoker=invoke_agent
+    )
+
+    # Our custom optimizer, plugged in exactly like any built-in one. It reuses the
+    # param-agnostic contrastive_reflection templates (they optimize whatever params
+    # the formula exposes — here the skill's "instructions").
+    optimizer = LLMJReferenceSkillOptimizer(
+        formula,
+        system_prompt_template=load_builtin_template("contrastive_reflection/system_prompt.jinja"),
+        task_message_template=load_builtin_template(
+            "contrastive_reflection/task_message_system_prompt.jinja"
+        ),
+        model_config={"model_id": "us.anthropic.claude-sonnet-4-20250514-v1:0"},
+        n_sample_traces=-1,
+    )
+
+    trainer = Trainer(
+        formula=formula,
+        optimizer=optimizer,
+        reward_fn=GSM8KReward(),
+        engine=engine,
+        dataloader=train_loader,
+        n_epochs=2,
+    )
+
+    print("\n=== Training the skill with LLMJReferenceSkillOptimizer ===")
+    print(f"Initial instructions: {formula.get_tunable_params()['instructions'][:100]}...")
+    stats = trainer.fit()
+    for s in stats:
+        print(f"  Epoch {s['epoch']}: avg_reward = {s['avg_reward']:.2f}")
+
+    # Confirm the optimization on a held-out split: the same agent now runs with the
+    # skill's optimized instructions (the formula re-syncs them into the plugin).
+    print("\n=== Held-out evaluation (optimized skill) ===")
+    reward_fn = GSM8KReward()
+    eval_agent = create_agent()
+    correct = 0
+    for i, sample in enumerate(test_data):
+        reward = reward_fn(invoke_agent(eval_agent, sample))
+        correct += reward.reward
+        status = "correct" if reward.reward == 1.0 else "wrong"
+        print(f"  [{i + 1}/{len(test_data)}] {status} "
+              f"(predicted={reward.metadata['predicted']}, expected={reward.metadata['expected']})")
+    print(f"Test accuracy: {correct / len(test_data):.0%}")
+
+    print(f"\nFinal optimized skill instructions:\n{formula.get_tunable_params()['instructions']}")
+
+    # Persist the optimized skill so the update outlives this process (training only
+    # mutated the in-memory Skill). It reloads with Skill.from_file(<dir>).
+    out_dir = os.path.join("optimized_skills", math_skill.name)
+    path = save_skill(math_skill, out_dir)
+    reloaded = Skill.from_file(out_dir)
+    assert reloaded.instructions == math_skill.instructions  # round-trip check
+    print(f"\nSaved optimized skill to {path} (reload via Skill.from_file('{out_dir}'))")
+
+
+if __name__ == "__main__":
+    main()

--- a/strands_harness_optimizer/adapters/strands_adapter.py
+++ b/strands_harness_optimizer/adapters/strands_adapter.py
@@ -51,7 +51,11 @@ TRIGGER_TIMING_MAP = {
 class StrandsAdapter(AgentAdapter):
     """Adapter that bridges Formulas to strands-agents via hooks."""
 
+    # Context keys written back by plain ``setattr`` on the agent.
     tunable_params: set[str] = {"system_prompt", "messages"}
+
+    # Name the AgentSkills plugin registers itself under in strands.
+    _SKILLS_PLUGIN_NAME = "agent_skills"
 
     def extract_context(self, agent: Agent) -> dict:
         """Extract context from a strands Agent.
@@ -60,23 +64,61 @@ class StrandsAdapter(AgentAdapter):
             agent: The strands Agent instance.
 
         Returns:
-            Dict with "system_prompt" and "messages" keys.
+            Dict with "system_prompt" and "messages" keys, plus "skills"
+            (the AgentSkills plugin's available skills) when the plugin is
+            attached to the agent.
         """
-        return {
+        context = {
             "system_prompt": agent.system_prompt,
             "messages": list(agent.messages) if hasattr(agent, "messages") else [],
         }
+        skills_plugin = self._get_skills_plugin(agent)
+        if skills_plugin is not None:
+            context["skills"] = skills_plugin.get_available_skills()
+        return context
 
     def update_context(self, agent: Agent, context: dict) -> None:
         """Apply updated context back to a strands Agent.
 
+        ``system_prompt``/``messages`` are set directly on the agent. ``skills``
+        is pushed into the AgentSkills plugin via ``set_available_skills()`` so
+        a Formula can drive skill definitions without touching plugin internals
+        or relying on a shared Skill reference.
+
         Args:
             agent: The strands Agent instance.
-            context: Dict with keys to update (e.g., "system_prompt", "messages").
+            context: Dict with keys to update (e.g., "system_prompt",
+                "messages", "skills").
         """
         for key in self.tunable_params:
             if key in context:
                 setattr(agent, key, context[key])
+
+        if "skills" in context:
+            skills_plugin = self._get_skills_plugin(agent)
+            if skills_plugin is None:
+                logger.warning(
+                    "Formula produced 'skills' but no AgentSkills plugin is "
+                    "attached to the agent; skipping skills update."
+                )
+            else:
+                skills_plugin.set_available_skills(context["skills"])
+
+    def _get_skills_plugin(self, agent: Agent):
+        """Return the agent's AgentSkills plugin, or None if not attached.
+
+        Located by plugin name (``AgentSkills.name == "agent_skills"``) via the
+        agent's plugin registry. Duck-typed on ``set_available_skills`` so the
+        adapter does not hard-depend on the AgentSkills class being importable.
+        """
+        registry = getattr(agent, "_plugin_registry", None)
+        plugins = getattr(registry, "_plugins", None)
+        if not plugins:
+            return None
+        plugin = plugins.get(self._SKILLS_PLUGIN_NAME)
+        if plugin is not None and hasattr(plugin, "set_available_skills"):
+            return plugin
+        return None
 
     def apply_to_agent(self, formulas: list[Formula], agent: Agent) -> Agent:
         """Register formulas as hook callbacks on a strands agent.

--- a/strands_harness_optimizer/formulas/__init__.py
+++ b/strands_harness_optimizer/formulas/__init__.py
@@ -2,6 +2,7 @@
 
 from .context_expansion_formula import ContextExpansionFormula
 from .formula import Formula
+from .skill_formula import SkillFormula
 from .system_prompt_formula import SystemPromptFormula
 
-__all__ = ["Formula", "SystemPromptFormula", "ContextExpansionFormula"]
+__all__ = ["Formula", "SystemPromptFormula", "ContextExpansionFormula", "SkillFormula"]

--- a/strands_harness_optimizer/formulas/skill_formula.py
+++ b/strands_harness_optimizer/formulas/skill_formula.py
@@ -1,0 +1,120 @@
+"""
+Built-in formula for Strands Agent Skill tuning.
+
+SkillFormula exposes a Strands ``Skill``'s ``description`` and/or ``instructions``
+as tunable parameters. Strands Skills use progressive disclosure: the
+``AgentSkills`` plugin injects a skill's ``name`` + ``description`` into the system
+prompt and loads the full ``instructions`` on demand when the agent activates the
+skill. Both the description (the discovery hook) and the instructions (the payload)
+are optimizable context.
+
+The ``Skill``/``AgentSkills`` classes are a newer Strands feature, so they are
+imported lazily in ``__init__`` — importing this module never fails on an older
+(but still supported) ``strands-agents``; only constructing a ``SkillFormula``
+requires a skills-capable version.
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+from strands.hooks.events import BeforeInvocationEvent
+
+from .formula import Formula
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from strands import Skill
+
+logger = logging.getLogger(__name__)
+
+
+class SkillFormula(Formula):
+    """Formula that manages a Strands ``Skill``'s text as tunable parameters.
+
+    The Formula is the single interface the optimizer talks to. The control flow is:
+
+        optimizer --update_params()--> Formula --process()--> adapter --> AgentSkills
+
+    - ``update_params`` (called by the optimizer) mutates the ``Skill`` this
+      formula owns.
+    - ``process`` (called by the adapter each invocation) returns the skill under
+      the ``"skills"`` context key; :class:`~strands_harness_optimizer.adapters.StrandsAdapter`
+      pushes it into the agent's ``AgentSkills`` plugin via ``set_available_skills()``.
+
+    This keeps the Formula authoritative over the skill definition instead of
+    relying on the plugin and formula happening to share the same ``Skill``
+    object — the adapter actively re-syncs the skill on every invocation.
+
+    Example:
+        from strands import Agent, AgentSkills, Skill
+
+        skill = Skill(name="math-solver", description="Solve math problems.",
+                      instructions="Solve the problem step by step.")
+        formula = SkillFormula(skill)               # tunes instructions by default
+
+        agent = Agent(plugins=[AgentSkills(skills=[skill])])
+        apply_formulas_on_strands_agent(agent, [formula])
+
+        formula.get_tunable_params()                # {'instructions': '...'}
+        formula.update_params({"instructions": "improved..."})
+
+    Args:
+        skill: The Strands ``Skill`` instance this formula owns and optimizes.
+        tune_description: If True, expose ``skill.description`` as a tunable param.
+        tune_instructions: If True, expose ``skill.instructions`` as a tunable param.
+    """
+
+    def __init__(
+        self,
+        skill: "Skill",
+        tune_description: bool = False,
+        tune_instructions: bool = True,
+    ):
+        # Lazy import: only constructing a SkillFormula requires a strands
+        # version that ships the AgentSkills plugin / Skill class.
+        try:
+            from strands import Skill  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "SkillFormula requires a strands-agents version that provides the "
+                "AgentSkills plugin (from strands import Skill, AgentSkills). "
+                "Upgrade strands-agents, or use SystemPromptFormula / "
+                "ContextExpansionFormula instead."
+            ) from e
+
+        if not (tune_description or tune_instructions):
+            raise ValueError(
+                "SkillFormula must tune at least one of description/instructions."
+            )
+
+        super().__init__(f"skill_formula:{skill.name}", [BeforeInvocationEvent])
+        self.skill = skill
+        self.tune_description = tune_description
+        self.tune_instructions = tune_instructions
+
+    def process(self, context: dict, **kwargs) -> dict:
+        """Hand the (possibly optimizer-updated) skill to the adapter.
+
+        Returns the skill under the ``"skills"`` key; the StrandsAdapter syncs it
+        into the AgentSkills plugin. ``system_prompt``/``messages`` are untouched.
+        """
+        return {"skills": [self.skill]}
+
+    def get_tunable_params(self) -> dict:
+        """Return the skill's tunable text (description and/or instructions)."""
+        params = {}
+        if self.tune_description:
+            params["description"] = self.skill.description
+        if self.tune_instructions:
+            params["instructions"] = self.skill.instructions
+        return params
+
+    def update_params(self, params: dict) -> None:
+        """Update the owned skill's text from a params dict."""
+        if self.tune_description and "description" in params:
+            self.skill.description = params["description"]
+            logger.info("Updated skill '%s' description (%d chars)",
+                        self.skill.name, len(params["description"]))
+        if self.tune_instructions and "instructions" in params:
+            self.skill.instructions = params["instructions"]
+            logger.info("Updated skill '%s' instructions (%d chars)",
+                        self.skill.name, len(params["instructions"]))

--- a/strands_harness_optimizer/templates/contrastive_reflection/task_message_system_prompt.jinja
+++ b/strands_harness_optimizer/templates/contrastive_reflection/task_message_system_prompt.jinja
@@ -1,21 +1,23 @@
-Analyze the trajectories and generate an optimized system prompt.
+Analyze the trajectories and generate optimized values for the parameters below.
 
 ## Inputs
 
 **Trajectory Folder**: {{ traces_folder }}
 
-**Current System Prompt to Optimize**:
-<current_system_prompt>
-{{ params.get("system_prompt", "") }}
-</current_system_prompt>
+**Parameters to Optimize** ({{ params | length }} total):
+{% for name, value in params.items() %}
+<parameter name="{{ name }}">
+{{ value }}
+</parameter>
+{% endfor %}
 
 ---
 
 ## CRITICAL: Output Requirements
 
-### 1. Preserve Original Prompt COMPLETELY
+### 1. Preserve Each Original Value COMPLETELY
 
-Your output MUST include the **ENTIRE original system prompt above, unchanged**. Do NOT:
+For every parameter, your output MUST include the **ENTIRE original value above, unchanged**. Do NOT:
 - Truncate any part of it
 - Modify existing content
 - Reorganize sections
@@ -23,10 +25,10 @@ Your output MUST include the **ENTIRE original system prompt above, unchanged**.
 
 ### 2. Append New Content at the END
 
-After the original prompt, append a new section with your insights:
+After each original value, append a new section with your insights:
 
 ```
-[ENTIRE ORIGINAL PROMPT - UNCHANGED]
+[ENTIRE ORIGINAL VALUE - UNCHANGED]
 
 ---
 
@@ -37,13 +39,18 @@ After the original prompt, append a new section with your insights:
 
 ### 3. Dynamic Budget for New Content
 
-The original system prompt is approximately **{{ params.get("system_prompt", "") | length }} characters**. Adjust your new content length accordingly:
+Size your new content to the original value's length (per parameter):
 
 | Original Size | New Content Budget |
 |---------------------|-------------------|
 | < 5,000 chars | 3,000 - 5,000 chars of new insights |
 | 5,000 - 15,000 chars | 2,000 - 4,000 chars of new insights |
 | > 15,000 chars | 1,000 - 2,000 chars of new insights |
+
+Current sizes:
+{% for name, value in params.items() %}
+- **{{ name }}**: approximately {{ value | length }} characters
+{% endfor %}
 
 Focus on **high-value insights** when budget is limited.
 
@@ -81,17 +88,26 @@ Focus on:
 - What mistakes do failed agents make?
 - What patterns appear across MULTIPLE traces (not one-off issues)?
 
-**Step 5: Generate optimized system prompt and submit**
+**Step 5: Generate optimized values and submit**
 
-Write the complete optimized system prompt (original + new insights) to a file, then submit it:
+Write the complete optimized value (original + new insights) for each parameter to
+its own file, then submit them **under their original parameter names**:
 ```bash
-# Write the optimized prompt to a file
-cat > /tmp/optimized_system_prompt.txt << 'PROMPT_EOF'
-[your optimized prompt here]
-PROMPT_EOF
+{% for name in params %}
+cat > /tmp/optimized_{{ name }}.txt << 'PARAM_EOF'
+[your optimized {{ name }} here]
+PARAM_EOF
+{% endfor %}
 ```
 
-Then call `submit_optimized_params(file_path_dict={"system_prompt": "/tmp/optimized_system_prompt.txt"})` to submit.
+Then call:
+```
+submit_optimized_params(file_path_dict={
+{% for name in params %}    "{{ name }}": "/tmp/optimized_{{ name }}.txt",
+{% endfor %}})
+```
+
+Submit **every** parameter listed above, using its exact original name as the key.
 
 ---
 
@@ -114,4 +130,5 @@ Reject vague insights like "be careful" or "consider edge cases".
 
 ---
 
-**Remember**: The original system prompt contains important examples and instructions. Preserving it completely is essential for good performance.
+**Remember**: Each original value contains important examples and instructions.
+Preserving it completely is essential for good performance.

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -62,3 +62,54 @@ def test_convenience_function(mock_agent):
     result = apply_formulas_on_strands_agent(mock_agent, [formula])
     mock_agent.add_hook.assert_called_once()
     assert result is mock_agent
+
+
+# --- Skills syncing (AgentSkills plugin) ---
+
+
+class _FakeSkillsPlugin:
+    """Minimal stand-in for the AgentSkills plugin's public surface."""
+
+    def __init__(self, skills):
+        self._skills = list(skills)
+
+    def get_available_skills(self):
+        return list(self._skills)
+
+    def set_available_skills(self, skills):
+        self._skills = list(skills)
+
+
+def _agent_with_plugin(plugin):
+    agent = MagicMock()
+    agent.system_prompt = "p"
+    agent.messages = []
+    # Mirror strands' agent._plugin_registry._plugins dict.
+    agent._plugin_registry._plugins = {"agent_skills": plugin} if plugin is not None else {}
+    return agent
+
+
+def test_extract_context_includes_skills_when_plugin_present(adapter):
+    plugin = _FakeSkillsPlugin(["skillA"])
+    agent = _agent_with_plugin(plugin)
+    context = adapter.extract_context(agent)
+    assert context["skills"] == ["skillA"]
+
+
+def test_extract_context_omits_skills_without_plugin(adapter):
+    agent = _agent_with_plugin(None)
+    context = adapter.extract_context(agent)
+    assert "skills" not in context
+
+
+def test_update_context_pushes_skills_into_plugin(adapter):
+    plugin = _FakeSkillsPlugin(["old"])
+    agent = _agent_with_plugin(plugin)
+    adapter.update_context(agent, {"skills": ["new1", "new2"]})
+    assert plugin.get_available_skills() == ["new1", "new2"]
+
+
+def test_update_context_skills_without_plugin_is_noop(adapter):
+    agent = _agent_with_plugin(None)
+    # Should warn and skip, not raise.
+    adapter.update_context(agent, {"skills": ["x"]})

--- a/tests/formulas/test_skill.py
+++ b/tests/formulas/test_skill.py
@@ -1,0 +1,82 @@
+"""Tests for SkillFormula."""
+
+import pytest
+from strands import Skill
+from strands.hooks.events import BeforeInvocationEvent
+
+from strands_harness_optimizer.formulas import SkillFormula
+
+
+def make_skill(name="math-solver", description="desc", instructions="instr"):
+    return Skill(name=name, description=description, instructions=instructions)
+
+
+class TestSkillFormulaInit:
+    def test_name_includes_skill_name(self):
+        formula = SkillFormula(make_skill())
+        assert formula.name == "skill_formula:math-solver"
+
+    def test_trigger_timings(self):
+        formula = SkillFormula(make_skill())
+        assert formula.trigger_timings == [BeforeInvocationEvent]
+
+    def test_requires_at_least_one_tunable(self):
+        with pytest.raises(ValueError):
+            SkillFormula(make_skill(), tune_description=False, tune_instructions=False)
+
+
+class TestSkillFormulaProcess:
+    def test_process_returns_skill_under_skills_key(self):
+        skill = make_skill()
+        formula = SkillFormula(skill)
+        result = formula.process({"system_prompt": "x", "messages": []})
+        assert result == {"skills": [skill]}
+
+
+class TestSkillFormulaTunableParams:
+    def test_instructions_only(self):
+        # Default construction tunes instructions only.
+        formula = SkillFormula(make_skill(instructions="i0"))
+        assert formula.get_tunable_params() == {"instructions": "i0"}
+
+    def test_description_only(self):
+        formula = SkillFormula(
+            make_skill(description="d0"),
+            tune_description=True,
+            tune_instructions=False,
+        )
+        assert formula.get_tunable_params() == {"description": "d0"}
+
+    def test_both(self):
+        formula = SkillFormula(
+            make_skill(description="d0", instructions="i0"),
+            tune_description=True,
+            tune_instructions=True,
+        )
+        assert formula.get_tunable_params() == {"description": "d0", "instructions": "i0"}
+
+
+class TestSkillFormulaUpdateParams:
+    def test_updates_instructions_in_place(self):
+        skill = make_skill(instructions="old")
+        formula = SkillFormula(skill)
+        formula.update_params({"instructions": "new"})
+        assert skill.instructions == "new"
+
+    def test_updates_description_when_tuned(self):
+        skill = make_skill(description="old")
+        formula = SkillFormula(skill, tune_description=True, tune_instructions=False)
+        formula.update_params({"description": "new"})
+        assert skill.description == "new"
+
+    def test_ignores_untuned_key(self):
+        skill = make_skill(description="orig")
+        formula = SkillFormula(skill)  # instructions only
+        formula.update_params({"description": "changed"})
+        assert skill.description == "orig"
+
+    def test_ignores_missing_key(self):
+        skill = make_skill(instructions="orig")
+        formula = SkillFormula(skill)
+        formula.update_params({})
+        assert skill.instructions == "orig"


### PR DESCRIPTION
## Summary

Adds first-class support for optimizing **Strands Agent Skills** with the harness, plus a worked example and a reference optimizer for teams writing their own LLM-driven algorithm.

- **`SkillFormula`** exposes a Strands Agent Skill's `description`/`instructions` as tunable parameters, so the existing `ContrastiveReflectionOptimizer` can rewrite skill text from rollout feedback the same way it optimizes system prompts. A lazy `strands.Skill` import keeps the `strands-agents>=1.0.0` floor: the module imports on any supported version, and only construction needs the AgentSkills feature. Exported from `strands_harness_optimizer.formulas`.
- **`StrandsAdapter`** now syncs a formula's skills into the agent's `AgentSkills` plugin via `set_available_skills()` on a new `"skills"` context key, so the Formula drives the skill through the adapter rather than relying on a shared `Skill` reference. The plugin is located by name; the adapter warns and skips when no AgentSkills plugin is attached.
- **Templates**: the `contrastive_reflection` task template is now param-agnostic. It loops over the formula's tunable params and submits each under its original key, so one optimizer and template work for `system_prompt`, skill `instructions`/`description`, and so on.
- **`examples/skill_optimization.py`** optimizes a Skill's instructions on GSM8K via the automated `Trainer` and `LocalRolloutEngine` loop.
- **`examples/skill_optimizer.py`** is a copy-paste reference for the "Path B" extension point (subclass `BaseAgenticOptimizer`). `LLMJReferenceSkillOptimizer` gives the reflection agent an LLM-as-judge tool via `_get_extra_tools()`, the same hook `MultiAgentOptimizer` uses for swarm. It shows the canonical `step()` flow, runs on GSM8K, evaluates on a held-out split, and persists the result to `optimized_skills/<name>/SKILL.md` (reloadable via `Skill.from_file`).

## Tests

Adds `tests/formulas/test_skill.py` (SkillFormula unit tests) and skills-sync cases in `tests/adapters/test_strands_adapter.py`.

## Commits

- `feat: add SkillFormula for optimizing Strands Agent Skills`
- `docs: add reference example for custom LLM-driven optimizers`