### PR TITLE
Add a WebShop multi-agent optimization example

### DIFF
--- a/examples/webshop/README.md
+++ b/examples/webshop/README.md
@@ -1,0 +1,85 @@
+# WebShop optimization example (multi-agent optimizer)
+
+Optimize an agent's system prompt on [WebShop](https://webshop-pnlp.github.io) shopping
+tasks with `strands_harness_optimizer`. WebShop tasks run inside a deployable **AgentCore
+runtime** (a Strands agent that shops against the WebShop gym via `search` / `click` /
+`buy now`); the **optimizer** drives that runtime over HTTP (local container) or by ARN
+(deployed), scores each task by WebShop's match score, and rewrites the system prompt.
+
+Unlike the [AppWorld example](../appworld) (single-agent reflection), this one uses the
+**`MultiAgentOptimizer`**: the reflection step spins up a **swarm of sub-agents** to
+analyze the rollouts in parallel before rewriting the prompt (see "Sub-agents" below).
+
+```
+webshop_agentcore_optimization.py          webshop_runtime/  (the deployable runtime)
+  DataLoader(task_ids)                        app.py  — AgentCore /invocations entrypoint
+  AgentCoreHTTPRolloutEngine ──HTTP POST──▶      → WebShopDataset runs the task,
+  (or AgentCoreRolloutEngine, by ARN)              returns {messages, eval_result}
+        │  payload_mapper: {data_sample,params}
+        ▼            → {task_id, system_prompt, exp_id}
+  WebShopReward (eval_result.metrics.score)
+        │
+  MultiAgentOptimizer.step()   ← swarm of sub-agents analyzes rollouts in parallel
+        → SystemPromptFormula.update_params()
+```
+
+## Sub-agents
+
+The optimizer here is `MultiAgentOptimizer`. Its reflection step is an **orchestrator**
+agent that uses the strands [`swarm`](https://strandsagents.com/latest/user-guide/concepts/multi-agent/agents-as-tools/)
+tool to create a team of **sub-agents**, each assigned a subset of the WebShop rollout
+traces. Every sub-agent (role: the `multi_agent/rollout_analyzer` template) extracts
+contrastive success/failure signals from its traces; the orchestrator aggregates those
+findings and appends them to the system prompt. This mirrors the internal
+`webshop_swarm_*` optimization configs. To use single-agent reflection instead, swap
+`MultiAgentOptimizer` for `ContrastiveReflectionOptimizer` (as the AppWorld example does).
+
+## Two pieces
+
+| Path | What it is |
+|------|-----------|
+| [`webshop_agentcore_optimization.py`](webshop_agentcore_optimization.py) | The **optimizer** (client). Runs the Trainer loop against the runtime with the multi-agent optimizer. Needs only `strands_harness_optimizer` + a runtime endpoint. |
+| [`webshop_runtime/`](webshop_runtime/) | The **deployable runtime** (container). Builds a Strands + WebShop-gym agent as an AgentCore runtime. See its [README](webshop_runtime/README.md). |
+| [`run_example.sh`](run_example.sh) | One-command driver: build the runtime, start it, wait for health, run the optimizer, clean up. |
+
+## Quick start (local container)
+
+One script builds the runtime, starts it, waits until healthy, and runs the optimizer
+against it (then cleans up the container). Run it from the repo root:
+
+```bash
+./examples/webshop/run_example.sh                    # defaults: Dockerfile.amd64, train split, port 8080
+./examples/webshop/run_example.sh -t 0,1,2 -p 8090   # custom tasks/port
+./examples/webshop/run_example.sh --build-only       # just build the image
+```
+
+It resolves AWS credentials from the environment/role (needed at runtime for Bedrock).
+See `run_example.sh --help`.
+
+Under the hood it's just these steps (do them manually if you prefer):
+
+```bash
+# 1. Build + run the runtime container (see webshop_runtime/README.md for prerequisites).
+docker build -f examples/webshop/webshop_runtime/Dockerfile.amd64 -t webshop-runtime .
+docker run -d -p 8080:8080 -e AWS_REGION=us-west-2 \
+  -e WEBSHOP_DATASET_SPLIT=train \
+  --name webshop-runtime webshop-runtime   # + AWS creds envs
+
+# 2. Optimize its system prompt against the container (multi-agent optimizer).
+export WEBSHOP_BASE_URL="http://localhost:8080"
+export WEBSHOP_TASK_IDS="0,1,2"     # optional subset; else the whole 'train' range (0-99)
+python examples/webshop/webshop_agentcore_optimization.py
+```
+
+To drive a **deployed** AgentCore runtime instead, set `WEBSHOP_AGENT_ARN` (and omit
+`WEBSHOP_BASE_URL`); the example auto-selects `AgentCoreRolloutEngine`.
+
+## Tasks & splits
+
+WebShop tasks are integer goal indices. A split is a contiguous range:
+
+- `train` → indices `0..99`
+- `eval`  → indices `0..199` (the held-out goals)
+
+Set `WEBSHOP_TASK_IDS` for a quick subset, or `WEBSHOP_SPLIT` to train on the whole
+range. The default dataset in the runtime is WebShop's small **1000-product** set.

--- a/examples/webshop/run_example.sh
+++ b/examples/webshop/run_example.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Build the WebShop runtime container, start it, wait until healthy, and run the
+# multi-agent system-prompt optimizer against it (the local-container / HTTP-engine path).
+#
+# Usage:
+#   ./run_example.sh [-f DOCKERFILE] [-s SPLIT] [-t TASK_IDS] [-p PORT] [--build-only] [--no-build]
+#
+#   -f  Dockerfile to build (default: webshop_runtime/Dockerfile.amd64 — fully public,
+#       Bedrock, dual venv). Use Dockerfile.arm64 for the arm64 build AgentCore runs.
+#   -s  Split to train on: train (goal indices 0-99) / eval (0-199). Default: train.
+#   -t  Comma-separated WebShop task ids (goal indices) to train on a SUBSET instead.
+#   -p  Host port to publish the runtime on (default: 8080).
+#   --build-only   Build the image and exit.
+#   --no-build     Skip building; assume the image already exists.
+#
+# This is the single setup+run script: it installs the client-side dependency
+# (strands_harness_optimizer, editable from this repo) if missing, builds the runtime
+# image, starts the container, waits for health, runs the optimizer, and cleans up.
+#
+# Requires: docker, python3, and AWS credentials in the environment/instance role (for
+# Bedrock at runtime).
+#
+# Run from the repository root (build context = repo root, per the Dockerfile COPY paths).
+
+set -euo pipefail
+
+# --- defaults ---
+DOCKERFILE="examples/webshop/webshop_runtime/Dockerfile.amd64"
+TASK_IDS=""          # empty => train on the FULL split range (see the optimizer)
+SPLIT="train"
+PORT="8080"
+IMAGE="webshop-runtime"
+CONTAINER="webshop-runtime"
+BUILD=1
+RUN_OPTIMIZER=1
+AWS_REGION="${AWS_REGION:-us-west-2}"
+
+# --- args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f) DOCKERFILE="$2"; shift 2 ;;
+    -t) TASK_IDS="$2"; shift 2 ;;      # subset override (comma-separated); else full split
+    -s) SPLIT="$2"; shift 2 ;;         # which split to train on (train/eval)
+    -p) PORT="$2"; shift 2 ;;
+    --build-only) RUN_OPTIMIZER=0; shift ;;
+    --no-build) BUILD=0; shift ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# --- must run from repo root (Dockerfile COPYs are repo-root relative) ---
+if [[ ! -f "$DOCKERFILE" ]]; then
+  echo "ERROR: $DOCKERFILE not found. Run this script from the repository root." >&2
+  exit 1
+fi
+
+# --- preflight: required tools + client-side Python dependency ---
+for tool in docker python3; do
+  command -v "$tool" >/dev/null || { echo "ERROR: '$tool' is required but not found." >&2; exit 1; }
+done
+if [[ "$RUN_OPTIMIZER" == "1" ]]; then
+  # The optimizer client needs strands_harness_optimizer. Install THIS repo (editable)
+  # if it isn't importable, so the client matches the code the container runs.
+  if ! python3 -c "import strands_harness_optimizer" >/dev/null 2>&1; then
+    echo ">> Installing strands_harness_optimizer (editable) from this repo ..."
+    python3 -m pip install -e . >/dev/null || {
+      echo "ERROR: failed to install strands_harness_optimizer. Install it manually:" >&2
+      echo "       python3 -m pip install -e ." >&2
+      exit 1
+    }
+  fi
+fi
+
+# --- resolve AWS credentials (needed for Bedrock at runtime) ---
+# Prefer explicit env vars; otherwise resolve the active chain via boto3 (works with
+# instance roles / profiles and both AWS CLI v1 and v2).
+AK="${AWS_ACCESS_KEY_ID:-}"; SK="${AWS_SECRET_ACCESS_KEY:-}"; TK="${AWS_SESSION_TOKEN:-}"
+if [[ -z "$AK" || -z "$SK" ]]; then
+  creds=$(python3 - <<'PY' 2>/dev/null || true
+import boto3
+c = boto3.Session().get_credentials()
+if c:
+    f = c.get_frozen_credentials()
+    print(f"{f.access_key}\t{f.secret_key}\t{f.token or ''}")
+PY
+)
+  if [[ -n "$creds" ]]; then
+    AK=$(printf '%s' "$creds" | cut -f1)
+    SK=$(printf '%s' "$creds" | cut -f2)
+    TK=$(printf '%s' "$creds" | cut -f3)
+  fi
+fi
+if [[ -z "$AK" || -z "$SK" ]]; then
+  echo "ERROR: no AWS credentials found (need them for Bedrock at runtime)." >&2
+  echo "       Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, or configure a profile/role." >&2
+  exit 1
+fi
+
+# --- build ---
+if [[ "$BUILD" == "1" ]]; then
+  echo ">> Building $IMAGE from $DOCKERFILE ..."
+  DOCKER_BUILDKIT=1 docker build -f "$DOCKERFILE" -t "$IMAGE" .
+fi
+[[ "$RUN_OPTIMIZER" == "0" ]] && { echo ">> Built $IMAGE. Exiting (--build-only)."; exit 0; }
+
+# --- run the container ---
+echo ">> Starting container $CONTAINER on port $PORT ..."
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+docker run -d --name "$CONTAINER" -p "$PORT:8080" \
+  -e AWS_ACCESS_KEY_ID="$AK" -e AWS_SECRET_ACCESS_KEY="$SK" -e AWS_SESSION_TOKEN="$TK" \
+  -e AWS_REGION="$AWS_REGION" \
+  -e WEBSHOP_DATASET_SPLIT="$SPLIT" \
+  -e BYPASS_TOOL_CONSENT=true \
+  "$IMAGE" >/dev/null
+
+cleanup() { docker rm -f "$CONTAINER" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# --- wait for health ---
+echo -n ">> Waiting for /ping "
+for _ in $(seq 1 60); do
+  code=$(curl -s -m 3 -o /dev/null -w "%{http_code}" "http://localhost:$PORT/ping" 2>/dev/null || echo 000)
+  [[ "$code" == "200" ]] && { echo " healthy."; break; }
+  echo -n "."; sleep 2
+done
+if [[ "${code:-000}" != "200" ]]; then
+  echo " runtime did not become healthy; last container logs:" >&2
+  docker logs --tail 30 "$CONTAINER" >&2
+  exit 1
+fi
+
+# --- run the optimizer against the container ---
+echo ">> Running the optimizer against http://localhost:$PORT ..."
+export WEBSHOP_BASE_URL="http://localhost:$PORT"
+export WEBSHOP_SPLIT="$SPLIT"
+
+if [[ -n "$TASK_IDS" ]]; then
+  export WEBSHOP_TASK_IDS="$TASK_IDS"
+  echo ">> Training on task subset: $TASK_IDS"
+else
+  unset WEBSHOP_TASK_IDS
+  echo ">> Training on the full '$SPLIT' split range"
+fi
+
+python3 examples/webshop/webshop_agentcore_optimization.py
+
+echo ">> Done."

--- a/examples/webshop/webshop_agentcore_optimization.py
+++ b/examples/webshop/webshop_agentcore_optimization.py
@@ -1,0 +1,230 @@
+"""Example: optimize a WebShop agent's system prompt with a **multi-agent** optimizer.
+
+WebShop (https://webshop-pnlp.github.io) tasks run inside an AgentCore *runtime* — a
+deployed Strands agent that talks to the WebShop gym environment (search / click /
+buy), completes the shopping task, and returns an evaluation. That heavy machinery
+(the WebShop gym, its search index, the dual-venv setup) lives server-side in the
+runtime, so this optimization script needs **only** ``strands_harness_optimizer`` plus
+AWS creds.
+
+The loop:
+
+    task_ids ─▶ AgentCore{HTTP,}RolloutEngine.invoke(runtime) ─▶ Rollout(eval_result)
+                     │  payload_mapper turns the engine's                 │
+                     │  {data_sample, params} into the runtime's          │
+                     │  {task_id, system_prompt, exp_id}                  ▼
+                     └───────────────────────────────────▶ WebShopReward (score → 1.0)
+                                                                          │
+                                              MultiAgentOptimizer.step()
+                                                → swarm of sub-agents analyzes rollouts
+                                                → SystemPromptFormula.update_params()
+
+**Sub-agents.** Unlike the AppWorld example (which uses a single reflection agent),
+this one uses ``MultiAgentOptimizer``: the reflection step is an orchestrator agent
+that spins up a **swarm of sub-agents** (via the strands ``swarm`` tool) to analyze
+the WebShop rollouts in parallel — each sub-agent digs into a subset of trajectories
+and reports contrastive success/failure signals, which the orchestrator aggregates
+into the updated system prompt. This mirrors the internal ``webshop_swarm_*``
+optimization configs.
+
+Runtime I/O contract (matches the deployed app.py):
+    request  payload : {"task_id": str, "system_prompt": str, "exp_id": str}
+    response payload : {"result", "messages", "stop_reason", "eval_result"}
+        eval_result  : {"reward": float, "metrics": {"success": bool, "score": float,
+                        "done": bool}, ...}   (make_eval_result)
+
+Requirements:
+    pip install strands-harness-optimizer
+
+Usage — point it at the runtime one of two ways:
+
+    # A) a LOCAL runtime container over HTTP (see examples/webshop/webshop_runtime):
+    docker run -p 8080:8080 ... webshop-runtime      # start the container
+    export WEBSHOP_BASE_URL="http://localhost:8080"  # or WEBSHOP_BASE_URLS=url1,url2 for a pool
+    python examples/webshop/webshop_agentcore_optimization.py
+
+    # B) a DEPLOYED AgentCore runtime by ARN (needs bedrock-agentcore:InvokeAgentRuntime):
+    export WEBSHOP_AGENT_ARN="arn:aws:bedrock-agentcore:us-west-2:123:runtime/webshop-xyz"
+    python examples/webshop/webshop_agentcore_optimization.py
+
+    export WEBSHOP_TASK_IDS="0,1,2,3"   # optional subset; else the whole split range
+"""
+
+import os
+
+from strands_harness_optimizer.data import DataLoader
+from strands_harness_optimizer.datamodels import Reward, Rollout
+from strands_harness_optimizer.formulas import SystemPromptFormula
+from strands_harness_optimizer.optimizers import MultiAgentOptimizer
+from strands_harness_optimizer.rewards import RewardFunction
+from strands_harness_optimizer.rollout_engines import (
+    AgentCoreHTTPRolloutEngine,
+    AgentCoreRolloutEngine,
+)
+from strands_harness_optimizer.trainer import Trainer
+from strands_harness_optimizer.utils import load_builtin_template
+
+
+# The starting system prompt is WebShop's operating instructions (tool protocol +
+# shopping strategy + a worked example). It's the `system_prompt` field of
+# webshop_runtime/prompts/webshop_instructions.yaml. The optimizer tunes this prompt;
+# the per-task shopping goal is supplied by the runtime as the user message.
+_PROMPT_YAML = os.path.join(
+    os.path.dirname(__file__), "webshop_runtime", "prompts", "webshop_instructions.yaml"
+)
+
+
+def _load_baseline_system_prompt() -> str:
+    import yaml
+
+    return yaml.safe_load(open(_PROMPT_YAML).read())["system_prompt"]
+
+
+WEBSHOP_SYSTEM_PROMPT = _load_baseline_system_prompt()
+
+
+# --- Reward: read the runtime's evaluation result ---
+
+class WebShopReward(RewardFunction):
+    """Reward = WebShop's task score in [0, 1].
+
+    The AgentCore runtime returns ``eval_result`` (a make_eval_result dict); the engine
+    stores it at ``rollout.metadata["eval_result"]``. WebShop pays a partial-match score
+    in [0, 1] on the final "buy now"; a full match is 1.0. We use that score directly as
+    the reward, and expose ``success`` (score == 1.0) in the metadata.
+    """
+
+    def __call__(self, rollout: Rollout) -> Reward:
+        eval_result = rollout.metadata.get("eval_result") or {}
+        metrics = eval_result.get("metrics", {}) if isinstance(eval_result, dict) else {}
+        score = float(metrics.get("score", eval_result.get("reward", 0.0)) or 0.0)
+        return Reward(
+            reward=score,
+            metadata={
+                "success": bool(metrics.get("success", score >= 1.0)),
+                "score": score,
+                "done": metrics.get("done"),
+            },
+        )
+
+
+# --- Payload mapping: canonical engine payload -> this runtime's shape ---
+
+def webshop_payload_mapper(payload: dict) -> dict:
+    """Map the engine's canonical payload to what the WebShop runtime expects.
+
+    AgentCoreRolloutEngine builds ``{"data_sample": {...}, "params": {...}}``. The
+    deployed runtime's ``invoke`` reads flat ``task_id`` / ``system_prompt`` / ``exp_id``
+    instead, so we flatten here. ``params`` carries the tuned SystemPromptFormula value.
+    """
+    data_sample = payload.get("data_sample", {})
+    params = payload.get("params", {})
+    return {
+        "task_id": data_sample.get("task_id", data_sample.get("id")),
+        "system_prompt": params.get("system_prompt", ""),
+        "exp_id": data_sample.get("exp_id", "harness-optimizer"),
+    }
+
+
+# --- Task data ---
+
+def load_task_samples() -> list[dict]:
+    """Load the task ids to train on.
+
+    1. WEBSHOP_TASK_IDS — an explicit comma-separated list of goal indices (quick subset).
+    2. Otherwise the whole split range: WEBSHOP_SPLIT (train => 0..99, eval => 0..199).
+
+    WebShop tasks are integer goal indices, so no CSV extraction is needed — the range
+    is defined by the split (see webshop_runtime/dataset/dataset.py).
+    """
+    env_ids = os.getenv("WEBSHOP_TASK_IDS")
+    if env_ids:
+        task_ids = [t.strip() for t in env_ids.split(",") if t.strip()]
+    else:
+        split = os.getenv("WEBSHOP_SPLIT", "train")
+        ranges = {"train": range(0, 100), "eval": range(0, 200)}
+        if split not in ranges:
+            raise SystemExit(f"Unknown WEBSHOP_SPLIT '{split}'. Use 'train' or 'eval'.")
+        task_ids = [str(i) for i in ranges[split]]
+
+    return [{"task_id": tid, "id": tid} for tid in task_ids]
+
+
+def main():
+    # Two ways to reach the WebShop runtime:
+    #   - WEBSHOP_BASE_URL(S): a local runtime *container* over HTTP (what
+    #     examples/webshop/webshop_runtime builds) — AgentCoreHTTPRolloutEngine.
+    #   - WEBSHOP_AGENT_ARN: a *deployed* AgentCore runtime — AgentCoreRolloutEngine.
+    base_urls = os.getenv("WEBSHOP_BASE_URLS") or os.getenv("WEBSHOP_BASE_URL")
+    agent_arn = os.getenv("WEBSHOP_AGENT_ARN")
+    if not base_urls and not agent_arn:
+        raise SystemExit(
+            "Set one of:\n"
+            "  WEBSHOP_BASE_URL(S)  — local runtime container(s), e.g. 'http://localhost:8080'\n"
+            "                         (comma-separated for a pool of containers)\n"
+            "  WEBSHOP_AGENT_ARN    — a deployed AgentCore runtime ARN"
+        )
+
+    task_samples = load_task_samples()
+    train_loader = DataLoader(task_samples, batch_size=len(task_samples))
+    print(f"WebShop tasks: {len(task_samples)}")
+
+    # The prompt we optimize. The runtime applies whatever system_prompt we send.
+    formula = SystemPromptFormula(system_prompt=WEBSHOP_SYSTEM_PROMPT)
+
+    # payload_mapper reshapes the canonical {data_sample, params} payload into the
+    # runtime's {task_id, system_prompt, exp_id} for either transport.
+    if base_urls:
+        urls = [u.strip() for u in base_urls.split(",") if u.strip()]
+        print(f"Driving {len(urls)} local runtime container(s) over HTTP: {urls}")
+        engine = AgentCoreHTTPRolloutEngine(
+            formula=formula,
+            base_urls=urls,
+            num_workers=len(urls),  # one in-flight request per container
+            payload_mapper=webshop_payload_mapper,
+        )
+    else:
+        print("Driving a deployed AgentCore runtime by ARN")
+        engine = AgentCoreRolloutEngine(
+            formula=formula,
+            agent_arn=agent_arn,
+            region_name=os.getenv("AWS_REGION", "us-west-2"),
+            num_workers=4,
+            payload_mapper=webshop_payload_mapper,
+        )
+
+    # The multi-agent optimizer: the reflection step spins up a swarm of sub-agents
+    # (via the strands `swarm` tool) to analyze the WebShop rollouts in parallel, then
+    # aggregates their contrastive findings into the updated system prompt. The
+    # `rollout_analyzer_template` is the role each sub-agent is given.
+    optimizer = MultiAgentOptimizer(
+        formula,
+        system_prompt_template=load_builtin_template("multi_agent/system_prompt.jinja"),
+        task_message_template=load_builtin_template(
+            "multi_agent/task_message_system_prompt.jinja"
+        ),
+        rollout_analyzer_template=load_builtin_template("multi_agent/rollout_analyzer.jinja"),
+        model_config={"model_id": "us.anthropic.claude-sonnet-4-20250514-v1:0"},
+        n_sample_traces=-1,
+    )
+
+    trainer = Trainer(
+        formula=formula,
+        optimizer=optimizer,
+        reward_fn=WebShopReward(),
+        engine=engine,
+        dataloader=train_loader,
+        n_epochs=1,
+    )
+
+    print("\n=== Optimizing WebShop system prompt (multi-agent, via AgentCore runtime) ===")
+    print(f"Initial prompt: {formula.get_tunable_params()['system_prompt'][:100]}...")
+    stats = trainer.fit()
+    for s in stats:
+        print(f"  Epoch {s['epoch']}: avg_reward (task score) = {s['avg_reward']:.2f}")
+
+    print(f"\nFinal optimized prompt:\n{formula.get_tunable_params()['system_prompt']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/webshop/webshop_runtime/Dockerfile.amd64
+++ b/examples/webshop/webshop_runtime/Dockerfile.amd64
@@ -1,0 +1,110 @@
+# Public, no internal dependencies: Python 3.12 base; uv from PyPI; the WebShop source
+# + data from the public princeton-nlp/webshop repo (was: private ECR base + custom 20k
+# data). Dual venv — VENV_AUX (Python 3.9) runs the WebShop gym server (its pinned ML
+# stack: pydantic v1, numpy<2, Flask 2.1, pyserini/Lucene), VENV_MAIN (3.12) runs strands
+# + the AgentCore runtime. openjdk is required by pyserini's Lucene search backend.
+FROM python:3.12-slim
+
+# Avoid interactive prompts and speed up installs
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Paths for the two virtualenvs
+ENV VENV_MAIN=/opt/venv_main \
+    VENV_AUX=/opt/venv_aux
+
+# Base tools + Java (pyserini/Lucene) + git (clone WebShop + git-lfs data if any).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    build-essential \
+    unzip \
+    git \
+    openjdk-17-jdk-headless \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+# --- Install uv (fast Python + env manager) from PyPI ---
+RUN pip install --no-cache-dir uv
+
+# --- Install Python 3.12 (agent) and 3.9 (WebShop gym) via uv ---
+RUN uv python install 3.12 3.9
+
+# --- Create the two virtualenvs ---
+RUN uv venv "$VENV_MAIN" --python 3.12 && \
+    uv venv "$VENV_AUX" --python 3.9
+
+WORKDIR /app
+
+# Copy dependency files first (better layer caching).
+COPY examples/webshop/webshop_runtime/main_requirements.txt \
+     examples/webshop/webshop_runtime/webshop_requirements.txt ./
+
+# Install into each env. The WebShop gym stack (pinned, pydantic v1) goes in AUX;
+# spaCy/blis need to be installed before the rest to get compatible wheels.
+RUN uv pip install --python "$VENV_MAIN/bin/python" --no-cache -r main_requirements.txt
+RUN uv pip install --python "$VENV_AUX/bin/python" --no-cache "blis==0.7.11" "spacy==3.5.4" && \
+    uv pip install --python "$VENV_AUX/bin/python" --no-cache -r webshop_requirements.txt && \
+    uv pip install --python "$VENV_AUX/bin/python" --no-cache \
+      https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0-py3-none-any.whl
+
+# --- Fetch the WebShop source from the PUBLIC GitHub repo (pinned commit) ---
+RUN git clone --quiet https://github.com/princeton-nlp/webshop.git ./webshop && \
+    git -C ./webshop checkout --quiet master
+ENV WEBSHOP_PATH=/app/webshop
+
+# --- Download the small (1000-product) WebShop dataset from the public Google Drive
+#     mirror via gdown (the same ids the upstream setup.sh uses for `-d small`). ---
+WORKDIR /app/webshop/data
+RUN "$VENV_AUX/bin/gdown" "https://drive.google.com/uc?id=1EgHdxQ_YxqIQlvvq5iKlCrkEKR6-j0Ib" && \
+    "$VENV_AUX/bin/gdown" "https://drive.google.com/uc?id=1IduG0xl544V_A_jv3tHXC0kyFi7PnyBu" && \
+    "$VENV_AUX/bin/gdown" "https://drive.google.com/uc?id=14Kb5SPBk_jfdLZ_CDBNitW98QLDlKR5O"
+
+# --- Point WebShop's engine at the 1000-product files (defaults are the full set) ---
+RUN sed -i \
+      -e "s#^DEFAULT_ATTR_PATH = .*#DEFAULT_ATTR_PATH = join(BASE_DIR, '../data/items_ins_v2_1000.json')#" \
+      -e "s#^DEFAULT_FILE_PATH = .*#DEFAULT_FILE_PATH = join(BASE_DIR, '../data/items_shuffle_1000.json')#" \
+      /app/webshop/web_agent_site/utils.py
+
+# --- Build the Lucene search index for the 1000-product set (indexes_1k) ---
+COPY examples/webshop/webshop_runtime/build_index.py /app/webshop/search_engine/build_index.py
+WORKDIR /app/webshop/search_engine
+RUN "$VENV_AUX/bin/python" build_index.py /app/webshop/data/items_shuffle_1000.json ./resources_1k && \
+    "$VENV_AUX/bin/python" -m pyserini.index.lucene \
+      --collection JsonCollection \
+      --input resources_1k \
+      --index indexes_1k \
+      --generator DefaultLuceneDocumentGenerator \
+      --threads 1 \
+      --storePositions --storeDocvectors --storeRaw
+
+WORKDIR /app
+
+# Install strands_harness_optimizer from THIS repo (not PyPI) so the runtime tracks the
+# current working code. Copy only what the wheel needs. Its version comes from git tags
+# via hatch-vcs; .git isn't in the build context, so pin the version explicitly.
+COPY pyproject.toml README.md ./harness_pkg/
+COPY strands_harness_optimizer ./harness_pkg/strands_harness_optimizer
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=0.0.2 \
+    uv pip install --python "$VENV_MAIN/bin/python" --no-cache ./harness_pkg
+
+# Copy runtime code (entrypoint, local helpers, dataset package, gym server, prompts).
+COPY examples/webshop/webshop_runtime/_local.py ./_local.py
+COPY examples/webshop/webshop_runtime/app_simple.py ./app_simple.py
+COPY examples/webshop/webshop_runtime/dataset ./dataset
+COPY examples/webshop/webshop_runtime/prompts ./prompts
+
+EXPOSE 8080
+
+ENV DOCKER_CONTAINER=1
+ENV WEBSHOP_EXECUTE_ENV=/opt/venv_aux
+ENV WEBSHOP_FLASK_URL=http://localhost:3000
+ENV WEBSHOP_NUM_PRODUCTS=1000
+ENV WEBSHOP_DATA_FILE=/app/webshop/data/items_shuffle_1000.json
+# No SYSTEM_PROMPT_YAML_PATH needed - prompt comes from the invocation payload.
+
+COPY examples/webshop/webshop_runtime/app.py ./app.py
+
+CMD uv run --python "$VENV_MAIN/bin/python" opentelemetry-instrument python -m app

--- a/examples/webshop/webshop_runtime/Dockerfile.arm64
+++ b/examples/webshop/webshop_runtime/Dockerfile.arm64
@@ -1,0 +1,110 @@
+# Public, no internal dependencies: Python 3.12 base (arm64 — what AgentCore runs); uv from PyPI; the WebShop source
+# + data from the public princeton-nlp/webshop repo (was: private ECR base + custom 20k
+# data). Dual venv — VENV_AUX (Python 3.9) runs the WebShop gym server (its pinned ML
+# stack: pydantic v1, numpy<2, Flask 2.1, pyserini/Lucene), VENV_MAIN (3.12) runs strands
+# + the AgentCore runtime. openjdk is required by pyserini's Lucene search backend.
+FROM --platform=linux/arm64 python:3.12-slim
+
+# Avoid interactive prompts and speed up installs
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Paths for the two virtualenvs
+ENV VENV_MAIN=/opt/venv_main \
+    VENV_AUX=/opt/venv_aux
+
+# Base tools + Java (pyserini/Lucene) + git (clone WebShop + git-lfs data if any).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    build-essential \
+    unzip \
+    git \
+    openjdk-17-jdk-headless \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-arm64
+
+# --- Install uv (fast Python + env manager) from PyPI ---
+RUN pip install --no-cache-dir uv
+
+# --- Install Python 3.12 (agent) and 3.9 (WebShop gym) via uv ---
+RUN uv python install 3.12 3.9
+
+# --- Create the two virtualenvs ---
+RUN uv venv "$VENV_MAIN" --python 3.12 && \
+    uv venv "$VENV_AUX" --python 3.9
+
+WORKDIR /app
+
+# Copy dependency files first (better layer caching).
+COPY examples/webshop/webshop_runtime/main_requirements.txt \
+     examples/webshop/webshop_runtime/webshop_requirements.txt ./
+
+# Install into each env. The WebShop gym stack (pinned, pydantic v1) goes in AUX;
+# spaCy/blis need to be installed before the rest to get compatible wheels.
+RUN uv pip install --python "$VENV_MAIN/bin/python" --no-cache -r main_requirements.txt
+RUN uv pip install --python "$VENV_AUX/bin/python" --no-cache "blis==0.7.11" "spacy==3.5.4" && \
+    uv pip install --python "$VENV_AUX/bin/python" --no-cache -r webshop_requirements.txt && \
+    uv pip install --python "$VENV_AUX/bin/python" --no-cache \
+      https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0-py3-none-any.whl
+
+# --- Fetch the WebShop source from the PUBLIC GitHub repo (pinned commit) ---
+RUN git clone --quiet https://github.com/princeton-nlp/webshop.git ./webshop && \
+    git -C ./webshop checkout --quiet master
+ENV WEBSHOP_PATH=/app/webshop
+
+# --- Download the small (1000-product) WebShop dataset from the public Google Drive
+#     mirror via gdown (the same ids the upstream setup.sh uses for `-d small`). ---
+WORKDIR /app/webshop/data
+RUN "$VENV_AUX/bin/gdown" "https://drive.google.com/uc?id=1EgHdxQ_YxqIQlvvq5iKlCrkEKR6-j0Ib" && \
+    "$VENV_AUX/bin/gdown" "https://drive.google.com/uc?id=1IduG0xl544V_A_jv3tHXC0kyFi7PnyBu" && \
+    "$VENV_AUX/bin/gdown" "https://drive.google.com/uc?id=14Kb5SPBk_jfdLZ_CDBNitW98QLDlKR5O"
+
+# --- Point WebShop's engine at the 1000-product files (defaults are the full set) ---
+RUN sed -i \
+      -e "s#^DEFAULT_ATTR_PATH = .*#DEFAULT_ATTR_PATH = join(BASE_DIR, '../data/items_ins_v2_1000.json')#" \
+      -e "s#^DEFAULT_FILE_PATH = .*#DEFAULT_FILE_PATH = join(BASE_DIR, '../data/items_shuffle_1000.json')#" \
+      /app/webshop/web_agent_site/utils.py
+
+# --- Build the Lucene search index for the 1000-product set (indexes_1k) ---
+COPY examples/webshop/webshop_runtime/build_index.py /app/webshop/search_engine/build_index.py
+WORKDIR /app/webshop/search_engine
+RUN "$VENV_AUX/bin/python" build_index.py /app/webshop/data/items_shuffle_1000.json ./resources_1k && \
+    "$VENV_AUX/bin/python" -m pyserini.index.lucene \
+      --collection JsonCollection \
+      --input resources_1k \
+      --index indexes_1k \
+      --generator DefaultLuceneDocumentGenerator \
+      --threads 1 \
+      --storePositions --storeDocvectors --storeRaw
+
+WORKDIR /app
+
+# Install strands_harness_optimizer from THIS repo (not PyPI) so the runtime tracks the
+# current working code. Copy only what the wheel needs. Its version comes from git tags
+# via hatch-vcs; .git isn't in the build context, so pin the version explicitly.
+COPY pyproject.toml README.md ./harness_pkg/
+COPY strands_harness_optimizer ./harness_pkg/strands_harness_optimizer
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=0.0.2 \
+    uv pip install --python "$VENV_MAIN/bin/python" --no-cache ./harness_pkg
+
+# Copy runtime code (entrypoint, local helpers, dataset package, gym server, prompts).
+COPY examples/webshop/webshop_runtime/_local.py ./_local.py
+COPY examples/webshop/webshop_runtime/app_simple.py ./app_simple.py
+COPY examples/webshop/webshop_runtime/dataset ./dataset
+COPY examples/webshop/webshop_runtime/prompts ./prompts
+
+EXPOSE 8080
+
+ENV DOCKER_CONTAINER=1
+ENV WEBSHOP_EXECUTE_ENV=/opt/venv_aux
+ENV WEBSHOP_FLASK_URL=http://localhost:3000
+ENV WEBSHOP_NUM_PRODUCTS=1000
+ENV WEBSHOP_DATA_FILE=/app/webshop/data/items_shuffle_1000.json
+# No SYSTEM_PROMPT_YAML_PATH needed - prompt comes from the invocation payload.
+
+COPY examples/webshop/webshop_runtime/app.py ./app.py
+
+CMD uv run --python "$VENV_MAIN/bin/python" opentelemetry-instrument python -m app

--- a/examples/webshop/webshop_runtime/README.md
+++ b/examples/webshop/webshop_runtime/README.md
@@ -1,0 +1,94 @@
+# WebShop AgentCore runtime
+
+This directory contains the **deployable runtime** for the WebShop optimization
+example. It packages a Strands agent that solves [WebShop](https://webshop-pnlp.github.io)
+shopping tasks and exposes it as a [Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/)
+runtime. Optimize its system prompt from the OSS harness with
+[`../webshop_agentcore_optimization.py`](../webshop_agentcore_optimization.py), which
+drives this runtime over HTTP (local container, `AgentCoreHTTPRolloutEngine`) or by ARN
+(deployed, `AgentCoreRolloutEngine`).
+
+```
+optimizer (this repo)  ──InvokeAgentRuntime──▶  WebShop runtime (this dir)
+   AgentCoreRolloutEngine                          app.py  →  WebShopDataset
+   MultiAgentOptimizer (swarm)                             →  WebShop gym + eval
+        ▲   tuned system_prompt in payload                  │
+        └───────────── eval_result (score) ─────────────────┘
+```
+
+## Layout
+
+This runtime depends only on **`strands_harness_optimizer`** + **`strands`** + the
+public **WebShop** source — there is no `agent_customizer` dependency. The few helpers
+it would otherwise import from that internal package are reproduced locally in
+`_local.py`.
+
+| Path | What it is |
+|------|-----------|
+| `app.py` | AgentCore entrypoint. `invoke(payload)` reads `task_id` / `system_prompt` / `exp_id`, runs the task, returns `{result, messages, stop_reason, eval_result}`. Uses `SystemPromptFormula` + `StrandsAdapter` from the OSS package. |
+| `_local.py` | Self-contained helpers (no `agent_customizer`): `make_eval_result`, `ManagedProcess`, `create_strands_agent`. |
+| `dataset/` | `WebShopDataset` (`dataset.py`, on top of `strands_harness_optimizer.data.Dataset` — task rows only), `WebShopEnvironment` (`environment.py` — runs/evaluates a task, owns the gym server + `search`/`click`/`get_available_actions` tools). |
+| `app_simple.py` | The WebShop gym server: a Flask wrapper over `WebAgentTextEnv` exposing `/reset`, `/step`, `/get_actions`, `/close`. Runs in `VENV_AUX`. |
+| `build_index.py` | Builds the Lucene search-index documents (run at image build). |
+| `prompts/webshop_instructions.yaml` | The baseline system prompt (tool protocol + shopping strategy) the optimizer starts from. |
+| `Dockerfile*` | Build variants (see below). |
+| `*_requirements.txt` | Python deps per virtualenv. |
+
+## Runtime I/O contract
+
+Request payload (what the engine + the example's `payload_mapper` send):
+```json
+{"task_id": "<goal index>", "system_prompt": "<prompt to run>", "exp_id": "<label>"}
+```
+Response payload:
+```json
+{"result": ..., "messages": [...], "stop_reason": null,
+ "eval_result": {"reward": 0.0, "metrics": {"success": false, "score": 0.0, "done": true}}}
+```
+The optimizer's `WebShopReward` reads `eval_result.metrics.score` (WebShop's [0,1]
+partial-match score; `success` = a full 1.0 match).
+
+## Dockerfile variants
+
+| File | Target | Notes |
+|------|--------|-------|
+| `Dockerfile.amd64` | linux/amd64 | **Fully public** (no ECR/S3): `python:3.12-slim` base, uv from PyPI, WebShop source + small (1000-product) data from the public `princeton-nlp/webshop` repo. **Dual venv** — `aux` (Python 3.9) runs the WebShop gym (pinned ML stack: pydantic v1, numpy<2, Flask 2.1, pyserini/Lucene), `main` (3.12) runs strands + the runtime. `openjdk` backs pyserini's Lucene. Bedrock backend. |
+| `Dockerfile.arm64` | linux/arm64 | Same fully-public dual-venv build for arm64 (what AgentCore runs). Differs from `.amd64` only in the `--platform` pin and the `JAVA_HOME` arch path. |
+
+## Build prerequisites
+
+Both Dockerfiles are **fully public** — no private ECR/S3. They:
+
+1. **WebShop source + data** — clone `github.com/princeton-nlp/webshop`, download the
+   small **1000-product** dataset from its public Google Drive mirror (the ids the
+   upstream `setup.sh -d small` uses), and build the Lucene index (`indexes_1k`) with
+   pyserini at build time. Needs network access and `openjdk`.
+2. **`strands_harness_optimizer`** is installed from **this repo** (copied into the
+   image, not PyPI), so the runtime tracks the current working code.
+
+The default is the small 1000-product set (fast, public). To use a larger set, override
+`WEBSHOP_NUM_PRODUCTS` / `WEBSHOP_DATA_FILE` and build the matching index (see WebShop's
+`search_engine/run_indexing.sh`).
+
+## Build & deploy (sketch)
+
+```bash
+# From this repo root. All variants are fully public. AgentCore runs arm64:
+docker build -f examples/webshop/webshop_runtime/Dockerfile.arm64 -t webshop-runtime .
+
+# Push to ECR and register as an AgentCore runtime, then grab the runtime ARN.
+# (Use your standard AgentCore deployment flow.)
+
+# Optimize its system prompt from this repo (multi-agent / swarm optimizer):
+export WEBSHOP_AGENT_ARN="arn:aws:bedrock-agentcore:us-west-2:<acct>:runtime/<id>"
+export WEBSHOP_TASK_IDS="0,1,2,3"       # optional subset; else the whole split range
+python examples/webshop/webshop_agentcore_optimization.py
+```
+
+## Note on imports
+
+`app.py` runs as a top-level module (`python -m app` from this directory, per the
+Dockerfiles' `WORKDIR /app`), so it imports its siblings directly: `from _local import
+create_strands_agent` and `from dataset import WebShopDataset`. If you relocate these
+files, keep them importable from the working directory (or turn the folder into a
+package and switch to relative imports).

--- a/examples/webshop/webshop_runtime/_local.py
+++ b/examples/webshop/webshop_runtime/_local.py
@@ -1,0 +1,222 @@
+"""Self-contained helpers for the AppWorld runtime example.
+
+These are the few small utilities the runtime needs that would otherwise come
+from the internal ``agent_customizer`` package. They are reproduced here (with
+no ``agent_customizer`` dependency) so this example depends only on
+``strands_harness_optimizer`` + ``strands`` + the ``appworld`` package:
+
+- ``make_eval_result`` — the plain-dict eval-result shape the reward reads.
+- ``ManagedProcess``   — start/stop a subprocess (the AppWorld env server),
+  waiting for a readiness line and draining stdout so its pipe never fills.
+- ``create_strands_agent`` — build a Strands ``Agent`` (Bedrock or an
+  OpenAI-compatible endpoint) with MCP + extra tools and a bounded window.
+"""
+
+import logging
+import os
+import select
+import signal
+import subprocess
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# --- eval result --------------------------------------------------------------
+
+def make_eval_result(
+    reward: float,
+    turn_rewards=None,
+    metrics=None,
+    messages=None,
+    system_prompt: str = "",
+    elapsed_time: int = 0,
+    session_id: str = None,
+) -> dict:
+    """Build a rollout-evaluation result as a plain dict with all keys present."""
+    return {
+        "reward": reward,
+        "turn_rewards": turn_rewards if turn_rewards is not None else {},
+        "metrics": metrics if metrics is not None else {},
+        "messages": messages if messages is not None else [],
+        "system_prompt": system_prompt,
+        "elapsed_time": elapsed_time,
+        "session_id": session_id,
+    }
+
+
+# --- managed subprocess (AppWorld environment server) -------------------------
+
+class ManagedProcess:
+    """Start a subprocess, wait for a readiness line, drain its stdout."""
+
+    def __init__(self, cmd, ready_pattern="SERVER READY", startup_timeout=10.0):
+        self.cmd = list(cmd)
+        self.ready_pattern = ready_pattern
+        self.startup_timeout = startup_timeout
+        self.proc: Optional[subprocess.Popen] = None
+        self._drain_thread: Optional[threading.Thread] = None
+
+    def start(self):
+        if self.is_running():
+            return
+        self.proc = subprocess.Popen(
+            self.cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,  # line-buffered
+            preexec_fn=os.setsid,
+        )
+        if not self._wait_until_ready():
+            self.stop()
+            raise RuntimeError("ManagedProcess failed to start correctly")
+        # After readiness we stop reading stdout, but the child keeps writing to
+        # it (the AppWorld env server logs every request). A PIPE has a bounded
+        # OS buffer (~64KB); once full the child blocks on write() and stops
+        # serving. Drain continuously in a daemon thread to keep it unblocked.
+        self._drain_thread = threading.Thread(target=self._drain_stdout, daemon=True)
+        self._drain_thread.start()
+
+    def _drain_stdout(self):
+        proc = self.proc
+        if proc is None or proc.stdout is None:
+            return
+        try:
+            for _ in proc.stdout:
+                pass  # discard; only need to keep the buffer drained
+        except (ValueError, OSError):
+            pass  # stdout closed on stop() — expected during shutdown
+
+    def _wait_until_ready(self) -> bool:
+        assert self.proc is not None
+        start_time = time.time()
+        stdout = self.proc.stdout
+        while True:
+            if time.time() - start_time > self.startup_timeout:
+                logger.warning("Startup timeout waiting for ready signal")
+                return False
+            if self.proc.poll() is not None:
+                logger.warning("Process exited early with code %s", self.proc.returncode)
+                if stdout:
+                    leftover = stdout.read()
+                    if leftover:
+                        logger.warning("Process output before exit:\n%s", leftover)
+                return False
+            if stdout is None:
+                return True
+            rlist, _, _ = select.select([stdout], [], [], 0.1)
+            if not rlist:
+                continue
+            line = stdout.readline()
+            if not line:
+                continue
+            if self.ready_pattern in line:
+                return True
+
+    def stop(self):
+        if not self.is_running():
+            return
+        try:
+            os.killpg(self.proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        finally:
+            self.proc = None
+
+    def is_running(self) -> bool:
+        return self.proc is not None and self.proc.poll() is None
+
+
+# --- Strands agent builder ----------------------------------------------------
+
+def create_strands_agent(
+    model_config: Dict[str, Any],
+    mcp_client: Optional[Any] = None,
+    additional_tools: Optional[List] = None,
+) -> Any:
+    """Create a Strands Agent (bedrock | openai) with MCP + extra tools.
+
+    Provider is chosen explicitly by ``model_config['provider']`` — no inference
+    and no fallback between providers; missing required fields raise.
+    """
+    from strands import Agent
+    from strands.agent.conversation_manager import SlidingWindowConversationManager
+
+    provider = model_config.get("provider", "bedrock")
+
+    if provider == "openai":
+        if not model_config.get("openai_base_url"):
+            raise ValueError("provider='openai' requires 'openai_base_url' in model_config")
+        if not model_config.get("model_id"):
+            raise ValueError("provider='openai' requires 'model_id' in model_config")
+        if not model_config.get("openai_api_key"):
+            raise ValueError(
+                "provider='openai' requires 'openai_api_key' in model_config "
+                "(use a placeholder like 'EMPTY' for servers that ignore it)"
+            )
+        from strands.models.openai import OpenAIModel
+        model = OpenAIModel(
+            client_args={
+                "base_url": model_config["openai_base_url"],
+                "api_key": model_config["openai_api_key"],
+            },
+            model_id=model_config["model_id"],
+            params={
+                "temperature": model_config.get("temperature", 0.0),
+                "max_tokens": model_config.get("max_tokens", 4096),
+            },
+        )
+        logger.info("Using OpenAI-compatible model '%s' at %s",
+                    model_config["model_id"], model_config["openai_base_url"])
+    elif provider == "bedrock":
+        if not model_config.get("model_id"):
+            raise ValueError("provider='bedrock' requires 'model_id' in model_config")
+        from botocore.config import Config as BotocoreConfig
+        from strands.models import BedrockModel
+
+        additional_request_fields = {}
+        if model_config.get("enable_thinking", True):
+            budget = model_config.get("thinking_budget_tokens", 2048)
+            additional_request_fields["thinking"] = {"type": "enabled", "budget_tokens": budget}
+
+        model = BedrockModel(
+            model_id=model_config["model_id"],
+            region_name=model_config.get("region", "us-west-2"),
+            boto_client_config=BotocoreConfig(retries={"max_attempts": 3, "mode": "adaptive"}),
+            streaming=model_config.get("streaming", False),
+            additional_request_fields=additional_request_fields,
+        )
+    else:
+        raise ValueError(
+            f"Unknown model provider '{provider}'. Set model_config['provider'] "
+            "to 'bedrock' or 'openai'."
+        )
+
+    tools = []
+    if mcp_client:
+        try:
+            with mcp_client:
+                mcp_tools = mcp_client.list_tools_sync()
+                tools.extend(mcp_tools)
+                logger.info("Added %d MCP tools", len(mcp_tools))
+        except Exception as e:
+            logger.warning("Failed to get MCP tools: %s", e)
+    if additional_tools:
+        tools.extend(additional_tools)
+        logger.info("Added %d additional tools", len(additional_tools))
+
+    conversation_manager = SlidingWindowConversationManager(
+        window_size=model_config.get("conversation_window_size", 40),
+        should_truncate_results=True,
+    )
+    agent = Agent(
+        model=model,
+        system_prompt=model_config.get("initial_prompt", ""),
+        tools=tools,
+        conversation_manager=conversation_manager,
+    )
+    logger.info("Created Strands agent with %d total tools", len(tools))
+    return agent

--- a/examples/webshop/webshop_runtime/app.py
+++ b/examples/webshop/webshop_runtime/app.py
@@ -1,0 +1,170 @@
+import os
+import sys
+
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+
+# ============================================================================
+# Configuration Section - All values configurable via environment variables
+# ============================================================================
+
+from bedrock_agentcore import BedrockAgentCoreApp
+from strands_harness_optimizer.adapters import StrandsAdapter
+from strands_harness_optimizer.formulas import SystemPromptFormula
+
+
+logger = logging.getLogger(__name__)
+
+# Default system prompt (can be overridden by YAML config or the invoke payload).
+DEFAULT_SYSTEM_PROMPT = os.getenv(
+    "DEFAULT_SYSTEM_PROMPT",
+    "You are a shopping agent that helps to complete WebShop tasks.",
+)
+
+# Dataset split (train / eval) and optional explicit task-id subset.
+DATASET_SPLIT = os.getenv("WEBSHOP_DATASET_SPLIT", "train")
+TASK_IDS_STR = os.getenv("WEBSHOP_TASK_IDS", None)
+TASK_IDS = TASK_IDS_STR.split(",") if TASK_IDS_STR else None
+
+# Whether to shuffle the dataset.
+SHUFFLE_DATASET = os.getenv("WEBSHOP_SHUFFLE", "false").lower() == "true"
+
+# Model configuration.
+MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0")
+
+# Model backend chosen explicitly via MODEL_PROVIDER ("bedrock" | "openai").
+# openai targets an OpenAI-compatible server (local vLLM); MODEL_ID then names
+# the served model (e.g. "qwen3-coder-30b"). No inference/fallback.
+MODEL_PROVIDER = os.getenv("MODEL_PROVIDER", "bedrock")
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+
+# System prompt YAML configuration path (optional).
+SYSTEM_PROMPT_YAML_PATH = os.getenv("SYSTEM_PROMPT_YAML_PATH", "")
+
+# Tool consent bypass.
+BYPASS_TOOL_CONSENT = os.getenv("BYPASS_TOOL_CONSENT", "true")
+
+# ============================================================================
+
+logger.info("Agent starting")
+logger.info(f"Configuration: MODEL_ID={MODEL_ID}, SPLIT={DATASET_SPLIT}")
+print("Agent Starting")
+
+os.environ["BYPASS_TOOL_CONSENT"] = BYPASS_TOOL_CONSENT
+
+from _local import create_strands_agent
+from dataset import WebShopDataset, WebShopEnvironment
+
+logger.info(f"Creating WebShop dataset (split={DATASET_SPLIT}, task_ids={TASK_IDS})")
+
+dataset = WebShopDataset(
+    split=DATASET_SPLIT,
+    task_ids=TASK_IDS,
+    shuffle=SHUFFLE_DATASET,
+)
+
+# The environment owns task execution/evaluation (gym server + shopping tools),
+# kept separate from the dataset which is just the task rows.
+environment = WebShopEnvironment()
+
+from omegaconf import OmegaConf
+
+# Load system prompt from YAML if a path is provided, otherwise use the default.
+if SYSTEM_PROMPT_YAML_PATH:
+    logger.info(f"Loading system prompt from: {SYSTEM_PROMPT_YAML_PATH}")
+    cfg = OmegaConf.load(SYSTEM_PROMPT_YAML_PATH)
+    system_prompt = cfg["system_prompt"]
+else:
+    logger.info("Using default system prompt")
+    system_prompt = DEFAULT_SYSTEM_PROMPT
+
+logger.info(f"Loaded system prompt: {system_prompt[:100]}...")
+
+_model_cfg = {
+    "model_id": MODEL_ID,
+    "initial_prompt": system_prompt,
+    "provider": MODEL_PROVIDER,
+}
+if MODEL_PROVIDER == "openai":
+    # Talk to a local vLLM (OpenAI-compatible) server instead of Bedrock.
+    # Required fields validated in create_strands_agent (raises if missing).
+    _model_cfg.update({
+        "openai_base_url": OPENAI_BASE_URL,
+        "openai_api_key": OPENAI_API_KEY,
+    })
+    logger.info(f"Model backend: openai @ {OPENAI_BASE_URL} (model={MODEL_ID})")
+elif MODEL_PROVIDER == "bedrock":
+    logger.info(f"Model backend: bedrock (model={MODEL_ID})")
+else:
+    raise ValueError(
+        f"Unknown MODEL_PROVIDER '{MODEL_PROVIDER}'. Set it to 'bedrock' or 'openai'."
+    )
+
+agent = create_strands_agent(
+    _model_cfg,
+    mcp_client=None,
+    additional_tools=environment.get_tools(),
+)
+
+app = BedrockAgentCoreApp()
+
+# Apply the system-prompt formula to the agent. Each invocation can override the
+# prompt (see invoke() below) — this is what the optimizer tunes.
+processor = SystemPromptFormula(system_prompt=system_prompt)
+adapter = StrandsAdapter()
+adapter.apply_to_agent([processor], agent)
+app.state.currently_busy = False
+
+logger.info("Agent started successfully")
+print("Agent Started")
+
+
+@app.entrypoint
+def invoke(payload):
+    """AI agent function for WebShop task execution."""
+    logger.info("=" * 60)
+    logger.info("Agent invocation start")
+    print("Agent invocation start")
+
+    processor_system_prompt = payload.get("system_prompt", system_prompt)
+    processor.update_params({"system_prompt": processor_system_prompt})
+
+    # Extract payload parameters.
+    task_id = payload.get("task_id")
+    exp_id = payload.get("exp_id", "default")
+
+    logger.info(f"Task ID: {task_id}")
+    logger.info(f"Experiment ID: {exp_id}")
+
+    # Look up the task (dataset) and run it (environment).
+    data_sample = dataset.get_data_by_id(task_id)
+    execute_fn = environment.get_execute_fn()
+
+    response = execute_fn(agent, data_sample)
+
+    # Evaluate the result.
+    eval_fn = environment.get_evaluate_fn()
+    eval_result = eval_fn(data_sample, agent.messages, response)
+
+    logger.info(
+        f"Evaluation complete. Reward: {eval_result.get('reward', 'N/A') if hasattr(eval_result, 'get') else 'N/A'}"
+    )
+    logger.info("Agent invocation complete")
+    logger.info("=" * 60)
+
+    return {
+        "result": response,
+        "messages": adapter.extract_context(agent)["messages"],
+        "stop_reason": None,
+        "eval_result": eval_result,
+    }
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/webshop/webshop_runtime/app_simple.py
+++ b/examples/webshop/webshop_runtime/app_simple.py
@@ -1,0 +1,167 @@
+"""
+Simple Flask wrapper for the WebShop gym environment.
+
+Wraps ``WebAgentTextEnv`` (from the public princeton-nlp/webshop repo) and exposes
+plain JSON endpoints (no HTML rendering). Runs in VENV_AUX (the WebShop dependency
+stack); the agent side (VENV_MAIN) reaches it over HTTP.
+
+Dataset size is configurable via env so the same file serves the public small set
+(1000 products) or a larger one:
+    WEBSHOP_NUM_PRODUCTS  number of products to load            (default: 1000)
+    WEBSHOP_DATA_FILE     path to the items_shuffle_*.json file (default: the 1000 set)
+    WEBSHOP_HUMAN_GOALS   "true"/"false" — use human-written goals (default: true)
+The Lucene index directory is chosen by WebShop's engine from num_products
+(1000 -> indexes_1k), built at image-build time.
+"""
+import os
+import sys
+
+# Add webshop to path (the repo checkout lives one dir up from search_engine).
+webshop_path = os.environ.get("WEBSHOP_PATH", "/app/webshop")
+if webshop_path not in sys.path:
+    sys.path.insert(0, webshop_path)
+
+from flask import Flask, request, jsonify
+from web_agent_site.envs import WebAgentTextEnv
+
+app = Flask(__name__)
+
+# Store env instances per session.
+envs = {}
+
+# Shared server for efficiency (loads products/search engine once).
+_shared_server = None
+
+# Configuration (env-overridable).
+WEBSHOP_NUM_PRODUCTS = int(os.environ.get("WEBSHOP_NUM_PRODUCTS", "1000"))
+WEBSHOP_DATA_FILE = os.environ.get(
+    "WEBSHOP_DATA_FILE",
+    os.path.join(webshop_path, "data", "items_shuffle_1000.json"),
+)
+WEBSHOP_HUMAN_GOALS = os.environ.get("WEBSHOP_HUMAN_GOALS", "true").lower() == "true"
+
+
+def get_shared_server():
+    """Lazily initialize the shared WebShop server (loads data + index once)."""
+    global _shared_server
+    if _shared_server is None:
+        from web_agent_site.envs.web_agent_text_env import SimServer
+
+        print("[app_simple] Configuration:", flush=True)
+        print(f"[app_simple]   num_products: {WEBSHOP_NUM_PRODUCTS}", flush=True)
+        print(f"[app_simple]   data_file: {WEBSHOP_DATA_FILE}", flush=True)
+        print(f"[app_simple]   human_goals: {WEBSHOP_HUMAN_GOALS}", flush=True)
+        print("[app_simple] Loading products and search engine...", flush=True)
+
+        _shared_server = SimServer(
+            base_url="http://127.0.0.1:3000",
+            file_path=WEBSHOP_DATA_FILE,
+            human_goals=WEBSHOP_HUMAN_GOALS,
+            num_products=WEBSHOP_NUM_PRODUCTS,
+        )
+        print(f"[app_simple] Loaded {len(_shared_server.goals)} goals", flush=True)
+    return _shared_server
+
+
+@app.route("/ping", methods=["GET"])
+def ping():
+    """Health check endpoint."""
+    return jsonify({"status": "healthy"})
+
+
+@app.route("/reset", methods=["POST"])
+def reset():
+    """Initialize/reset the environment for a task.
+
+    Request JSON: {"task_id": 0, "session_id": "abc123"}
+    Response JSON: {"observation", "instruction", "available_actions", "session_id"}
+    """
+    data = request.json
+    task_id = data.get("task_id", 0)
+    session_id = data.get("session_id", f"session_{task_id}")
+
+    env = WebAgentTextEnv(
+        observation_mode="text",
+        server=get_shared_server(),
+        human_goals=WEBSHOP_HUMAN_GOALS,
+    )
+    obs, _ = env.reset(session=task_id)
+    envs[session_id] = env
+
+    return jsonify({
+        "observation": obs,
+        "instruction": env.instruction_text,
+        "available_actions": env.get_available_actions(),
+        "session_id": session_id,
+    })
+
+
+@app.route("/step", methods=["POST"])
+def step():
+    """Execute an action.
+
+    Request JSON: {"session_id": "abc123", "action": "search[blue headphones]"}
+    Response JSON: {"observation", "reward", "done", "available_actions"}
+    """
+    data = request.json
+    session_id = data.get("session_id")
+    action = data.get("action")
+
+    if session_id not in envs:
+        return jsonify({"error": f"Session {session_id} not found. Call /reset first."}), 400
+    if not action:
+        return jsonify({"error": "action is required"}), 400
+
+    env = envs[session_id]
+    obs, reward, done, info = env.step(action)
+
+    response = {
+        "observation": obs,
+        "reward": reward,
+        "done": done,
+        "available_actions": env.get_available_actions(),
+    }
+    if done:
+        del envs[session_id]
+    return jsonify(response)
+
+
+@app.route("/get_actions", methods=["POST"])
+def get_actions():
+    """Get available actions for the current state.
+
+    Request JSON: {"session_id": "abc123"}
+    Response JSON: {"has_search_bar", "clickables"}
+    """
+    data = request.json
+    session_id = data.get("session_id")
+    if session_id not in envs:
+        return jsonify({"error": f"Session {session_id} not found"}), 400
+    env = envs[session_id]
+    return jsonify(env.get_available_actions())
+
+
+@app.route("/close", methods=["POST"])
+def close():
+    """Close a session and free resources.
+
+    Request JSON: {"session_id": "abc123"}
+    """
+    data = request.json
+    session_id = data.get("session_id")
+    if session_id in envs:
+        del envs[session_id]
+        return jsonify({"status": "closed", "session_id": session_id})
+    return jsonify({"status": "not_found", "session_id": session_id})
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Simple WebShop Flask Server")
+    parser.add_argument("--port", type=int, default=3000, help="Port to run on")
+    parser.add_argument("--host", type=str, default="0.0.0.0", help="Host to bind to")
+    args = parser.parse_args()
+
+    print(f"[app_simple] Starting server on {args.host}:{args.port}", flush=True)
+    app.run(host=args.host, port=args.port, threaded=True)

--- a/examples/webshop/webshop_runtime/build_index.py
+++ b/examples/webshop/webshop_runtime/build_index.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Build the WebShop Lucene search-index documents from a products JSON file.
+
+WebShop's engine picks the index directory from num_products (1000 -> indexes_1k);
+this writes the matching `search_engine/resources_1k/documents.jsonl` collection,
+which is then indexed with pyserini at image-build time. Mirrors the upstream
+`search_engine/convert_product_file_format.py`, but reads the small 1000-product
+file (public) and writes the 1k collection directly.
+
+Usage:
+    build_index.py <items_shuffle_1000.json> <resources_out_dir>
+"""
+import json
+import sys
+
+
+def main() -> None:
+    data_file, out_dir = sys.argv[1], sys.argv[2]
+    with open(data_file) as f:
+        all_products = json.load(f)
+    print(f"Loaded {len(all_products)} products from {data_file}")
+
+    docs = []
+    for p in all_products:
+        option_texts = []
+        options = p.get("options", p.get("customization_options", {}))
+        if options:
+            for name, contents in options.items():
+                if contents is None:
+                    continue
+                if isinstance(contents, list):
+                    if contents and isinstance(contents[0], dict):
+                        text = ", ".join(o.get("value", str(o)) for o in contents)
+                    else:
+                        text = ", ".join(str(o) for o in contents)
+                else:
+                    text = str(contents)
+                option_texts.append(f"{name}: {text}")
+        option_text = ", and ".join(option_texts)
+
+        title = p.get("Title", p.get("name", ""))
+        description = p.get("Description", p.get("full_description", ""))
+        bullets = p.get("BulletPoints", p.get("small_description", [""]))
+        bullet_text = (bullets[0] if bullets else "") if isinstance(bullets, list) else bullets
+
+        docs.append({
+            "id": p["asin"],
+            "contents": " ".join([title, description, bullet_text, option_text]).lower(),
+            "product": p,
+        })
+
+    import os
+
+    os.makedirs(out_dir, exist_ok=True)
+    out_file = os.path.join(out_dir, "documents.jsonl")
+    with open(out_file, "w") as f:
+        for doc in docs:
+            f.write(json.dumps(doc) + "\n")
+    print(f"Wrote {len(docs)} documents to {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/webshop/webshop_runtime/dataset/__init__.py
+++ b/examples/webshop/webshop_runtime/dataset/__init__.py
@@ -1,0 +1,4 @@
+from .dataset import WebShopDataSample, WebShopDataset
+from .environment import WebShopEnvironment
+
+__all__ = ["WebShopDataSample", "WebShopDataset", "WebShopEnvironment"]

--- a/examples/webshop/webshop_runtime/dataset/dataset.py
+++ b/examples/webshop/webshop_runtime/dataset/dataset.py
@@ -1,0 +1,139 @@
+"""
+WebShop dataset — the task rows only.
+
+A minimal map-style dataset built directly on strands_harness_optimizer's Dataset
+(so it's DataLoader/Sampler-compatible). WebShop tasks are identified by an integer
+index into the benchmark's goal list; a split just selects a contiguous range of
+those indices. Running/evaluating a task lives in WebShopEnvironment
+(dataset/environment.py) — the dataset is just the data.
+"""
+
+import logging
+import random
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from strands_harness_optimizer.data import Dataset
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WebShopDataSample:
+    """A single WebShop task — just a task id (index into the goal list)."""
+
+    id: str = ""
+    input: str = ""
+    task_id: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        if not self.input:
+            self.input = self.task_id
+
+    def get(self, item, default=None):
+        return getattr(self, item, default)
+
+    def __getitem__(self, item):
+        return getattr(self, item)
+
+
+class WebShopDataset(Dataset[WebShopDataSample]):
+    """WebShop benchmark dataset (map-style, lazily loaded).
+
+    WebShop ships one instruction per goal; tasks are addressed by the goal's
+    integer index. A split is a contiguous range of indices:
+
+        train : indices [0, 100)
+        eval  : indices [0, 200)  (offset by +100 at run time, i.e. the held-out set)
+
+    The environment (WebShopEnvironment) resets the WebShop gym to ``task_id`` to
+    fetch the task instruction and score the final purchase.
+    """
+
+    name = "webshop"
+    description = "WebShop benchmark for evaluating agents on e-commerce shopping tasks"
+
+    # Default index ranges per split (mirrors the internal WebShop dataset).
+    _SPLIT_RANGES = {
+        "train": (0, 100),
+        "eval": (0, 200),
+    }
+
+    def __init__(
+        self,
+        split: str = "train",
+        start_idx: int = 0,
+        end_idx: int = 0,
+        task_ids: List[str] | None = None,
+        shuffle: bool = False,
+        shuffle_seed: int | None = None,
+    ):
+        self.split = split
+        self.task_ids = task_ids
+        self.shuffle = shuffle
+        self.shuffle_seed = shuffle_seed
+
+        if end_idx > 0:
+            self.start_idx, self.end_idx = start_idx, end_idx
+        elif split in self._SPLIT_RANGES:
+            self.start_idx, self.end_idx = self._SPLIT_RANGES[split]
+        else:
+            raise ValueError(
+                f"Unknown split '{split}'. Use one of {list(self._SPLIT_RANGES)}, "
+                "or pass explicit start_idx/end_idx."
+            )
+        # eval indices are the held-out goals after the train range.
+        self._offset = 0 if split == "train" else 100
+
+        self.data: List[WebShopDataSample] = []
+        self.data_index: Dict[str, WebShopDataSample] = {}
+        self._loaded = False
+
+    # --- map-style Dataset surface (DataLoader-compatible) ---
+
+    def ensure_loaded(self) -> None:
+        if not self._loaded:
+            self.load()
+
+    def __len__(self) -> int:
+        self.ensure_loaded()
+        return len(self.data)
+
+    def __getitem__(self, idx: int) -> WebShopDataSample:
+        self.ensure_loaded()
+        return self.data[idx]
+
+    def get_data_by_id(self, task_id: str) -> WebShopDataSample:
+        self.ensure_loaded()
+        return self.data_index[str(task_id)]
+
+    # --- loading ---
+
+    def load(self) -> None:
+        """Create one sample per goal index in the split's range."""
+        logger.info(
+            f"Creating WebShop dataset: split={self.split}, "
+            f"range=[{self.start_idx}, {self.end_idx}), offset={self._offset}"
+        )
+        for idx in range(self.start_idx, self.end_idx):
+            task_id = str(idx)
+            self.data.append(
+                WebShopDataSample(id=task_id, task_id=task_id, input=str(idx + self._offset))
+            )
+
+        # An explicit task_ids subset trims the split (used for quick runs).
+        if self.task_ids:
+            wanted = {str(t) for t in self.task_ids}
+            self.data = [s for s in self.data if s.task_id in wanted]
+
+        self._apply_shuffle()
+        self.data_index = {s.task_id: s for s in self.data}
+        self._loaded = True
+        logger.info(f"Loaded {len(self.data)} WebShop tasks")
+
+    def _apply_shuffle(self) -> None:
+        if not self.shuffle:
+            return
+        rng = random.Random(self.shuffle_seed)
+        rng.shuffle(self.data)

--- a/examples/webshop/webshop_runtime/dataset/environment.py
+++ b/examples/webshop/webshop_runtime/dataset/environment.py
@@ -1,0 +1,223 @@
+"""
+WebShop task environment.
+
+Owns the *execution* side of running WebShop tasks (separate from the dataset,
+which only holds the task rows): starting the WebShop gym server (a Flask wrapper
+around ``WebAgentTextEnv``), exposing the agent's shopping tools
+(``search`` / ``click`` / ``get_available_actions``), running the agent against a
+task, and turning the final purchase reward into an eval-result dict.
+
+The WebShop gym (``app_simple.py``) runs in a separate virtualenv (``VENV_AUX``,
+pinned to the WebShop dependency stack) and is reached over HTTP — the agent side
+(strands + newer deps) never imports the gym, mirroring the internal dual-venv
+design. Each task ``reset``s the gym to a goal index, and the goal's *instruction*
+becomes the per-task user message.
+"""
+
+import json
+import logging
+import os
+from contextlib import contextmanager
+
+import httpx
+from strands import tool
+
+from _local import ManagedProcess, make_eval_result
+
+logger = logging.getLogger(__name__)
+
+# The per-task USER message: the shopping goal fetched from the environment.
+# The operating instructions (tool protocol + strategy) are the SYSTEM prompt —
+# the thing the optimizer tunes (see prompts/webshop_instructions.yaml).
+_USER_MESSAGE_TEMPLATE = "Shopping task:\n{instruction}"
+
+
+class WebShopEnvironment:
+    """Runs WebShop tasks against a WebShop gym server.
+
+    Usage:
+        env = WebShopEnvironment()
+        agent = create_strands_agent(cfg, additional_tools=env.get_tools())
+        result = env.get_execute_fn()(agent, data_sample)   # runs + evaluates the task
+        eval_result = env.get_evaluate_fn()(data_sample, agent.messages, result)
+    """
+
+    def __init__(self, flask_url: str | None = None):
+        # The WebShop gym (app_simple.py) lives in this venv (set by the image),
+        # and is served over HTTP at flask_url.
+        self.flask_url = flask_url or os.environ.get("WEBSHOP_FLASK_URL", "http://localhost:3000")
+        self.webshop_aux_env = os.environ.get("WEBSHOP_EXECUTE_ENV", "")
+        self.webshop_path = os.environ.get("WEBSHOP_PATH", "/app/webshop")
+        # Per-task interaction state, set by the execute fn while a task runs.
+        self._session_id: str | None = None
+        # The final reward WebShop returns on a `buy now` (done=True) step.
+        self._last_reward = 0.0
+        self._done = False
+        self._server: ManagedProcess | None = None
+
+    # --- gym server lifecycle -------------------------------------------------
+
+    def _ensure_server(self) -> None:
+        """Start the WebShop gym Flask server once (loads products + search index)."""
+        if self._server and self._server.is_running():
+            return
+        try:
+            with httpx.Client(timeout=2.0) as c:
+                if c.get(f"{self.flask_url}/ping").status_code == 200:
+                    logger.info("WebShop gym already running")
+                    return
+        except httpx.HTTPError:
+            pass
+
+        python_bin = os.path.join(self.webshop_aux_env, "bin/python")
+        app_simple = os.path.join(os.path.dirname(os.path.dirname(__file__)), "app_simple.py")
+        logger.info("Starting WebShop gym server (app_simple.py) ...")
+        # Loading the 20k product index takes a while — allow a generous startup window.
+        self._server = ManagedProcess(
+            [python_bin, app_simple, "--port", "3000"],
+            ready_pattern="Loaded",  # app_simple prints "[app_simple] Loaded N goals"
+            startup_timeout=float(os.environ.get("WEBSHOP_STARTUP_TIMEOUT", "900")),
+        )
+        self._server.start()
+        logger.info("WebShop gym server ready")
+
+    # --- agent tools (search / click / get_available_actions) -----------------
+
+    def get_tools(self) -> list:
+        """The shopping tools the agent uses (search / click / get_available_actions).
+
+        These POST to the gym server's /step and /get_actions endpoints, tracking the
+        final reward the environment emits when the agent clicks "buy now".
+        """
+
+        def _step(action: str) -> dict:
+            with httpx.Client(timeout=120.0) as c:
+                r = c.post(
+                    f"{self.flask_url}/step",
+                    json={"session_id": self._session_id, "action": action},
+                )
+                r.raise_for_status()
+                result = r.json()
+            # Capture the terminal reward (WebShop only pays out on the buy-now step).
+            if "reward" in result:
+                self._last_reward = float(result.get("reward", 0.0) or 0.0)
+            if result.get("done"):
+                self._done = True
+            return result
+
+        @tool
+        def search(query: str) -> str:
+            """Search WebShop for products with space-separated keywords.
+
+            Returns a text observation listing matching products (names, prices, ASINs).
+            Example: search("blue wireless headphones")
+            """
+            if not query or not query.strip():
+                return json.dumps({"error": "Empty search query", "success": False})
+            result = _step(f"search[{query.strip()}]")
+            return json.dumps({
+                "observation": result.get("observation", ""),
+                "reward": result.get("reward", 0.0),
+                "done": result.get("done", False),
+                "available_actions": result.get("available_actions", {}),
+                "success": True,
+            })
+
+        @tool
+        def click(element: str) -> str:
+            """Click an element in WebShop.
+
+            Valid elements: product ASINs (e.g. "b09kqnh5c6"), "buy now" (purchase),
+            "back to search", "< prev", "next >", product options (e.g. "blue",
+            "large"), and info tabs ("description", "features", "reviews").
+            Returns a text observation of the resulting page.
+            """
+            if not element or not element.strip():
+                return json.dumps({"error": "Empty element", "success": False})
+            result = _step(f"click[{element.strip().lower()}]")
+            return json.dumps({
+                "observation": result.get("observation", ""),
+                "reward": result.get("reward", 0.0),
+                "done": result.get("done", False),
+                "available_actions": result.get("available_actions", {}),
+                "success": True,
+            })
+
+        @tool
+        def get_available_actions() -> str:
+            """List all clickable elements on the current WebShop page.
+
+            Returns whether a search bar is available and the list of clickable elements.
+            """
+            with httpx.Client(timeout=120.0) as c:
+                r = c.post(f"{self.flask_url}/get_actions", json={"session_id": self._session_id})
+                r.raise_for_status()
+                result = r.json()
+            return json.dumps({
+                "has_search_bar": result.get("has_search_bar", False),
+                "clickables": result.get("clickables", []),
+                "success": True,
+            })
+
+        return [search, click, get_available_actions]
+
+    # --- per-task run ---------------------------------------------------------
+
+    @contextmanager
+    def task_context(self, task_id: str):
+        """Reset the gym to ``task_id`` and yield the task instruction."""
+        self._ensure_server()
+        self._session_id = f"session_{task_id}"
+        self._last_reward = 0.0
+        self._done = False
+        with httpx.Client(timeout=900.0) as c:  # first reset may build/load the index
+            r = c.post(
+                f"{self.flask_url}/reset",
+                json={"task_id": int(task_id), "session_id": self._session_id},
+            )
+            r.raise_for_status()
+            reset = r.json()
+        try:
+            yield reset.get("instruction", "")
+        finally:
+            with httpx.Client(timeout=30.0) as c:
+                try:
+                    c.post(f"{self.flask_url}/close", json={"session_id": self._session_id})
+                except httpx.HTTPError:
+                    pass
+            self._session_id = None
+
+    def get_execute_fn(self):
+        """Return fn(agent, data) that runs one task against the WebShop gym."""
+        def fn(agent, data):
+            with self.task_context(data["task_id"]) as instruction:
+                logger.info(f"Task {data['task_id']}: {instruction[:120]}")
+                user_message = _USER_MESSAGE_TEMPLATE.format(instruction=instruction)
+                response = agent(user_message)
+                return {
+                    "id": data["task_id"],
+                    "message": response.message,
+                    "messages": agent.messages,
+                    "reward": self._last_reward,
+                    "done": self._done,
+                    "success": self._last_reward > 0,
+                }
+        return fn
+
+    def get_evaluate_fn(self):
+        """Return fn(data, rollout_data, execute_result) -> eval-result dict."""
+        def fn(data, rollout_data, execute_result):
+            reward = float(execute_result.get("reward", 0.0) or 0.0)
+            return make_eval_result(
+                reward=reward,
+                metrics={
+                    # Persist success so the RewardFunction reads it directly.
+                    # WebShop reward is a [0, 1] match score; "success" = a full match.
+                    "success": reward >= 1.0,
+                    "score": reward,
+                    "done": bool(execute_result.get("done", False)),
+                },
+                turn_rewards=[],
+                messages=rollout_data,
+            )
+        return fn

--- a/examples/webshop/webshop_runtime/main_requirements.txt
+++ b/examples/webshop/webshop_runtime/main_requirements.txt
@@ -1,0 +1,24 @@
+# Agent-side deps (VENV_MAIN, Python 3.12): the Strands agent + AgentCore runtime.
+# The WebShop gym and its heavy ML stack live in VENV_AUX (see webshop_requirements.txt).
+requests
+httpx
+pandas
+numpy
+pyyaml
+# NOTE: strands_harness_optimizer is installed from THIS repo (copied into the image),
+# not PyPI — so the runtime tracks the current working code, not the last release.
+# See the Dockerfiles' "install strands_harness_optimizer from this repo" step.
+# 1.33.0: strands-harness-optimizer needs BeforeModelCallEvent (newer strands API);
+# older releases lack it and the runtime fails to import.
+strands-agents==1.33.0
+strands-agents-tools
+strands-agents-builder
+opentelemetry-api
+opentelemetry-sdk
+aws-opentelemetry-distro
+boto3==1.40.67
+openai
+bedrock-agentcore
+dotenv
+hydra-core
+tiktoken==0.11

--- a/examples/webshop/webshop_runtime/prompts/webshop_instructions.yaml
+++ b/examples/webshop/webshop_runtime/prompts/webshop_instructions.yaml
@@ -1,0 +1,80 @@
+# @package _global_.prompt
+# WebShop system prompt
+
+system_prompt: |-
+  You are an expert online shopping assistant designed to help users find and purchase products that match their specific requirements on an e-commerce website.
+
+  Your goal is to navigate the shopping website efficiently and complete purchase tasks by:
+  1. Understanding the user's product requirements completely
+  2. Searching for relevant products using appropriate keywords
+  3. Evaluating product details to ensure they match ALL requirements
+  4. Selecting the correct product options (size, color, etc.)
+  5. Completing the purchase by clicking "buy now"
+
+  ## Available Tools
+
+  You have access to three tools to interact with the website:
+
+  ### 1. search(query: str)
+  Search for products using space-separated keywords.
+  - Keywords are matched against product titles, descriptions, and attributes
+  - Use specific keywords that capture the essential requirements
+  - Examples: "red shirt large", "wooden toy", "laptop bag waterproof"
+
+  ### 2. click(element: str)
+  Click on elements like product links, buttons, or options.
+  - Product ASINs (e.g., "b09mnnbdtj") - to view product details
+  - Navigation: "next >", "< prev", "back to search"
+  - Options: "red", "blue", "small", "medium", "large", etc.
+  - Tabs: "description", "features", "reviews", "attributes"
+  - Action: "buy now" - to complete purchase (USE THIS WHEN READY!)
+
+  ### 3. get_available_actions()
+  Get a list of all clickable elements on the current page.
+  - Use this when you're unsure what actions are available
+  - Helpful when clicks are failing or you need to see all options
+  - Returns: has_search_bar boolean and list of clickable elements
+
+  ## Task Completion Strategy
+
+  1. **Understand Requirements**: Carefully read the task to identify all product requirements (type, color, size, features, etc.)
+
+  2. **Search Effectively**:
+     - Use relevant keywords that match the product requirements
+     - Start with general terms, then refine if needed
+     - Review search results to find promising products
+
+  3. **Evaluate Products**:
+     - Click on product ASINs to view details
+     - Check description, features, and attributes tabs
+     - Verify the product matches ALL requirements from the task
+
+  4. **Select Options**:
+     - If the product has options (size, color), select the ones matching requirements
+     - Use get_available_actions() if you need to see what options are available
+
+  5. **Complete Purchase**:
+     - Once you've found a product that matches all requirements and selected appropriate options
+     - Click "buy now" to complete the task
+     - This will end the episode and you'll receive a reward
+
+  ## Important Tips
+
+  - Be thorough: Verify all requirements before purchasing
+  - If search results don't match, try different keywords
+  - Use get_available_actions() when uncertain about next steps
+  - Don't buy products that only partially match requirements
+  - Read product details carefully - don't assume based on title alone
+
+  ## Example Workflow
+
+  Task: "Find a red shirt in size large"
+
+  1. search("red shirt large")
+  2. Click on promising product ASIN
+  3. Check description/features to verify it's actually red
+  4. Look for size options and click("large")
+  5. Verify all requirements are met
+  6. click("buy now")
+
+  Now let's complete your shopping task!

--- a/examples/webshop/webshop_runtime/webshop_requirements.txt
+++ b/examples/webshop/webshop_runtime/webshop_requirements.txt
@@ -1,0 +1,26 @@
+# WebShop gym deps (VENV_AUX, Python 3.9): the WebAgentTextEnv + its search stack.
+# These pin the WebShop dependency set (pinned to what the upstream repo needs), which
+# conflicts with the agent side (pydantic v1, numpy<2, Flask 2.1) — hence the dual venv.
+# Mirrors princeton-nlp/webshop's requirements_arm.txt.
+beautifulsoup4==4.11.1
+cleantext==1.1.4
+env==0.1.0
+Flask==2.1.2
+werkzeug<2.1
+gdown
+gym==0.24.0
+numpy<2
+pandas==1.4.2
+pyserini==0.17.0
+PyYAML==6.0.1
+rank_bm25==0.2.2
+requests==2.27.1
+rich==12.4.4
+scikit_learn==1.1.1
+thefuzz==0.19.0
+torch==1.11.0
+tqdm==4.64.0
+train==0.0.5
+transformers==4.23.1
+pydantic==1.10.26
+faiss-cpu


### PR DESCRIPTION
## Summary

Adds `examples/webshop`, a full WebShop optimization example. It mirrors the AppWorld example (PR #9) but uses the **`MultiAgentOptimizer`** (a swarm of sub-agents) for the reflection step, as in the internal `webshop_swarm_*` configs. Now that `AgentCoreHTTPRolloutEngine` is on `main`, this branch depends on it directly and no longer carries its own copy.

- **`webshop_agentcore_optimization.py`** is the optimizer client. It drives a WebShop AgentCore runtime over HTTP (`AgentCoreHTTPRolloutEngine`) or by ARN, scores each task by WebShop's [0,1] match score (`WebShopReward`), and rewrites the system prompt with `MultiAgentOptimizer`, an orchestrator that spins up a swarm of sub-agents to analyze rollouts in parallel before appending learned insights to the prompt.
- **`webshop_runtime/`** is the deployable runtime container. `app.py` is the AgentCore entrypoint; `WebShopDataset` (task rows on `strands_harness_optimizer.data.Dataset`) and `WebShopEnvironment` (gym server plus `search`/`click`/`get_available_actions` tools) split data from execution. `app_simple.py` is the WebShop gym Flask wrapper. The fully-public dual-venv Dockerfiles (amd64/arm64) pair a Python 3.12 agent venv with a Python 3.9 WebShop-gym venv, pull the WebShop source and small (1000-product) data from the public `princeton-nlp/webshop` repo, and build the Lucene index at build time. It depends only on `strands_harness_optimizer` plus `strands` plus the public WebShop source (no `agent_customizer`); the few helpers it would otherwise import are reproduced in `_local.py`.
- **`run_example.sh`** is a one-command build, run, and optimize driver.

## How it differs from the AppWorld example

The AppWorld example uses single-agent `ContrastiveReflectionOptimizer`. This one uses `MultiAgentOptimizer`: the reflection step is an orchestrator that uses the strands `swarm` tool to create sub-agents, each analyzing a subset of the rollout traces and reporting contrastive success/failure signals that the orchestrator aggregates into the updated prompt.

## Verification

Client-side checks pass with the harness installed editable: dataset load and split offsets and subset filtering, `WebShopReward` (partial and full match), the payload mapper, all three `multi_agent/*` templates load, `MultiAgentOptimizer` constructs and exposes the `swarm` tool, and the runtime `WebShopEnvironment` builds its three tools and eval function. The Docker build itself was not run here (it needs network access for gdown and Java).

## Commit

- `docs: add WebShop multi-agent prompt-optimization example`