### PR TITLE
Add skill-library optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,5 +131,11 @@ strands_harness_optimizer/_version.py
 # Example output (optimized skills written by examples/skill_optimizer.py)
 optimized_skills/
 
+# Skill-library optimization output: run artifacts (decisions, manifests, skill
+# sets) and the folder a runtime unpacks an inline skills payload into.
+appworld_skill_runs/
+webshop_skill_runs/
+_skills/
+
 # AppWorld task CSVs are generated at build time (examples/appworld/appworld_runtime/generate_csvs.py)
 datasets/appworld/

--- a/README.md
+++ b/README.md
@@ -169,12 +169,16 @@ strands_harness_optimizer/
 ├── formulas/                       # Formula framework
 │   ├── formula.py                  # Formula ABC
 │   ├── system_prompt_formula.py   # Built-in: SystemPromptFormula
-│   └── context_expansion_formula.py # Built-in: ContextExpansionFormula
+│   ├── context_expansion_formula.py # Built-in: ContextExpansionFormula
+│   ├── skill_formula.py           # Built-in: SkillFormula (one skill's text)
+│   └── skill_library_formula.py   # Built-in: SkillLibraryFormula (a skill library)
 ├── optimizers/                     # Optimization framework
 │   ├── optimizer.py                # FormulaOptimizer ABC
-│   └── system_prompt/              # Built-in optimizers
-│       ├── base_agentic_optimizer.py   # BaseAgenticOptimizer
-│       └── contrastive_reflection.py   # ContrastiveReflectionOptimizer
+│   ├── base_agentic_optimizer.py   # BaseAgenticOptimizer (Formula-agnostic)
+│   ├── system_prompt/              # Built-in optimizers
+│   │   └── contrastive_reflection.py   # ContrastiveReflectionOptimizer
+│   └── skills/
+│       └── skill_library.py        # SkillLibraryOptimizer
 ├── rewards/                        # Reward computation
 │   └── reward_function.py         # RewardFunction ABC
 ├── rollout_engines/                # Agent rollout generation

--- a/docs/user-guide/optimizers.md
+++ b/docs/user-guide/optimizers.md
@@ -69,7 +69,7 @@ class StatefulOptimizer(FormulaOptimizer):
 
 ## BaseAgenticOptimizer
 
-`BaseAgenticOptimizer` is the base class for optimizers that use a strands Agent with tools to analyze rollouts. It provides infrastructure that specific agentic optimizers build on:
+`BaseAgenticOptimizer` is the base class for optimizers that use a strands Agent with tools to analyze rollouts. It is Formula-agnostic — `ContrastiveReflectionOptimizer` (system prompts, skill text) and `SkillLibraryOptimizer` (a whole skill library) both build on it. It provides infrastructure that specific agentic optimizers build on:
 
 - In-memory trace sampling (random or stratified by reward)
 - Writing sampled traces to temp folders as JSON

--- a/examples/appworld/README.md
+++ b/examples/appworld/README.md
@@ -24,6 +24,7 @@ appworld_agentcore_optimization.py         appworld_runtime/  (the deployable ru
 |------|-----------|
 | [`appworld_agentcore_optimization.py`](appworld_agentcore_optimization.py) | The **optimizer** (client). Runs the Trainer loop against the runtime. Needs only `strands_harness_optimizer` + a runtime endpoint. |
 | [`appworld_runtime/`](appworld_runtime/) | The **deployable runtime** (container). Builds a Strands+AppWorld agent as an AgentCore runtime. See its [README](appworld_runtime/README.md). |
+| [`appworld_skill_library_optimization.py`](appworld_skill_library_optimization.py) | The **skill-library** optimizer (client). Curates the SET of skills the agent has, instead of tuning the system prompt. |
 | [`run_example.sh`](run_example.sh) | One-command driver: build the runtime, start it, wait for health, run the optimizer, clean up. |
 
 ## Quick start (local container)
@@ -57,3 +58,32 @@ python examples/appworld/appworld_agentcore_optimization.py
 
 To drive a **deployed** AgentCore runtime instead, set `APPWORLD_AGENT_ARN` (and omit
 `APPWORLD_BASE_URL`); the example auto-selects `AgentCoreRolloutEngine`.
+
+## Two surfaces on one runtime
+
+The same container serves both optimizers — it applies whatever the payload carries:
+
+| surface | client | what it optimizes | payload key |
+|---|---|---|---|
+| system prompt | `appworld_agentcore_optimization.py` | the prompt text | `system_prompt` |
+| skill library | `appworld_skill_library_optimization.py` | which skills exist (create / revise / retire) | `skills_folder` |
+
+```bash
+./examples/appworld/run_example.sh              # system prompt (default)
+./examples/appworld/run_example.sh --skills     # skill library
+```
+
+Skills travel **inline** in the payload as `[{path, content}]`, not as an S3 pointer,
+so no bucket and no extra IAM are needed — and a saved trace records the skill text the
+agent actually read. Measured skill sets are 8–20 KB, well inside a payload. For a
+library that outgrows that (or carries binary resources), switch to uploading the
+materialized folder and sending a URI instead; `install_skills` in the runtime's
+`_local.py` is the only place that would change.
+
+The runtime echoes `skills_applied` in its response, and the client checks it. That is
+what distinguishes *"the skills did not help"* from *"the skills never loaded"* — a
+runtime built before the `skills_folder` key ignores it silently, and the resulting flat
+reward looks identical to a real null result.
+
+Reward for the curator comes from the same place as the prompt optimizer's:
+`eval_result.metrics.success` — success (binary).

--- a/examples/appworld/appworld_runtime/_local.py
+++ b/examples/appworld/appworld_runtime/_local.py
@@ -10,6 +10,8 @@ no ``agent_customizer`` dependency) so this example depends only on
   waiting for a readiness line and draining stdout so its pipe never fills.
 - ``create_strands_agent`` — build a Strands ``Agent`` (Bedrock or an
   OpenAI-compatible endpoint) with MCP + extra tools and a bounded window.
+- ``install_skills`` — materialize an inline ``skills_folder`` payload onto disk
+  and (re)attach the ``AgentSkills`` plugin, for skill-library optimization.
 """
 
 import logging
@@ -136,11 +138,16 @@ def create_strands_agent(
     model_config: Dict[str, Any],
     mcp_client: Optional[Any] = None,
     additional_tools: Optional[List] = None,
+    plugins: Optional[List] = None,
 ) -> Any:
     """Create a Strands Agent (bedrock | openai) with MCP + extra tools.
 
     Provider is chosen explicitly by ``model_config['provider']`` — no inference
     and no fallback between providers; missing required fields raise.
+
+    ``plugins`` is passed straight to ``Agent(plugins=...)``. It exists so a
+    runtime can attach ``AgentSkills`` (skill optimization); ``None`` keeps the
+    previous behaviour exactly.
     """
     from strands import Agent
     from strands.agent.conversation_manager import SlidingWindowConversationManager
@@ -212,11 +219,120 @@ def create_strands_agent(
         window_size=model_config.get("conversation_window_size", 40),
         should_truncate_results=True,
     )
-    agent = Agent(
+    agent_kwargs = dict(
         model=model,
         system_prompt=model_config.get("initial_prompt", ""),
         tools=tools,
         conversation_manager=conversation_manager,
     )
-    logger.info("Created Strands agent with %d total tools", len(tools))
+    # Only pass `plugins` when there are some: an older strands may not accept the
+    # kwarg at all, and every existing caller passes None.
+    if plugins:
+        agent_kwargs["plugins"] = plugins
+    agent = Agent(**agent_kwargs)
+    logger.info(
+        "Created Strands agent with %d total tools and %d plugin(s)",
+        len(tools),
+        len(plugins or []),
+    )
     return agent
+
+
+# --- skills (skill-library optimization) --------------------------------------
+
+SKILLS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_skills")
+
+
+def install_skills(agent: Any, skills_folder: Optional[List[Dict[str, str]]]) -> int:
+    """Write an inline skills payload to disk and (re)attach ``AgentSkills``.
+
+    ``skills_folder`` is the wire shape the skill-library optimizer sends:
+    ``[{"path": "<name>/SKILL.md", "content": "..."}, ...]``. Skills travel INSIDE
+    the payload rather than as an S3 pointer, so the runtime needs no bucket and
+    no credentials beyond what it already has, and a saved trace records the skill
+    text that actually ran.
+
+    The plugin is REBUILT on every call rather than mutated. ``AgentSkills`` reads
+    a filesystem path once, at ``init_agent`` time, so rewriting the folder under a
+    live plugin would not change what the agent sees -- the optimizer's new skills
+    would silently never load, which is indistinguishable from "the skills did not
+    help".
+
+    Returns the number of skills installed (0 clears them).
+    """
+    import shutil
+
+    from strands import AgentSkills
+
+    # Fresh directory each time: a skill the optimizer RETIRED must disappear, and
+    # leaving it on disk would keep it loadable.
+    shutil.rmtree(SKILLS_DIR, ignore_errors=True)
+    os.makedirs(SKILLS_DIR, exist_ok=True)
+
+    for item in skills_folder or []:
+        rel = str(item.get("path") or "").lstrip("/")
+        if not rel or ".." in rel.split("/"):
+            logger.warning("skipping suspicious skills_folder path %r", rel)
+            continue
+        dest = os.path.join(SKILLS_DIR, rel)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "w") as f:
+            f.write(item.get("content") or "")
+
+    names = sorted(
+        d for d in os.listdir(SKILLS_DIR)
+        if os.path.isfile(os.path.join(SKILLS_DIR, d, "SKILL.md"))
+    )
+
+    registry = getattr(agent, "_plugin_registry", None)
+    plugins = getattr(registry, "_plugins", None)
+    if plugins is None:
+        logger.warning("agent has no plugin registry; cannot install skills")
+        return 0
+
+    # Drop any previously-installed AgentSkills before adding the new one.
+    existing = plugins.get("agent_skills")
+    if existing is not None:
+        del plugins["agent_skills"]
+
+    if not names:
+        logger.info("skills cleared (no skills in payload)")
+        return 0
+
+    plugin = AgentSkills(skills=SKILLS_DIR)
+    registry.add_and_init(plugin)
+
+    # Report what the AGENT can see, not merely what we wrote: a skill whose
+    # frontmatter is damaged is written but never loadable, and counting files would
+    # call that a success.
+    #
+    # Filesystem skills are resolved per-agent during init_agent, so the resolved
+    # set is only reachable by passing the agent -- and that parameter exists in
+    # newer strands only (1.47 `get_available_skills(self, agent=None)`, 1.33
+    # `get_available_skills(self)`). On the older signature the return value is the
+    # construction-time list, which is EMPTY for a directory-loaded plugin, so it
+    # cannot be used to verify anything; fall back to the files written rather than
+    # reporting a spurious zero.
+    verified = True
+    try:
+        loaded = [s.name for s in plugin.get_available_skills(agent)]
+    except TypeError:
+        loaded, verified = names, False
+
+    if not verified:
+        logger.info(
+            "installed %d skill(s): %s (file count -- this strands version cannot "
+            "report the agent's resolved set, so a skill with damaged frontmatter "
+            "would not be caught here)",
+            len(loaded), ", ".join(sorted(loaded)),
+        )
+    elif len(loaded) != len(names):
+        logger.warning(
+            "wrote %d skill(s) %s but the agent resolved %d %s -- the difference "
+            "could not be loaded (check YAML frontmatter: `name:` and "
+            "`description:` are required)",
+            len(names), names, len(loaded), loaded,
+        )
+    else:
+        logger.info("installed %d skill(s): %s", len(loaded), ", ".join(sorted(loaded)))
+    return len(loaded)

--- a/examples/appworld/appworld_runtime/app.py
+++ b/examples/appworld/appworld_runtime/app.py
@@ -70,7 +70,7 @@ print("Agent Starting")
 
 os.environ["BYPASS_TOOL_CONSENT"] = BYPASS_TOOL_CONSENT
 
-from _local import create_strands_agent
+from _local import create_strands_agent, install_skills
 from dataset import AppWorldDataset, AppWorldEnvironment
 
 logger.info(f"Creating AppWorld dataset with tasks: {TASK_IDS}")
@@ -158,6 +158,14 @@ def invoke(payload):
         "system_prompt": processor_system_prompt
     })
 
+    # Skill-library optimization: the optimizer ships its current skill set INLINE
+    # as [{path, content}]. Absent the key nothing changes, so a prompt-only run is
+    # unaffected. Installed per invocation because the set changes between
+    # iterations, and AgentSkills reads its folder only at plugin-init time.
+    n_skills = 0
+    if "skills_folder" in payload:
+        n_skills = install_skills(agent, payload.get("skills_folder"))
+
     # Extract payload parameters
     task_id = payload.get("task_id")
     exp_id = payload.get("exp_id", "default")
@@ -189,7 +197,11 @@ def invoke(payload):
         "result": response,
         "messages": adapter.extract_context(agent)["messages"],
         "stop_reason": None,
-        "eval_result": eval_result
+        "eval_result": eval_result,
+        # Echoed so the client can tell "the skills did not help" apart from "the
+        # skills never loaded" -- a runtime that predates the payload key ignores
+        # it silently, and the resulting null delta looks identical to a real one.
+        "skills_applied": n_skills,
     }
 
 if __name__ == "__main__":

--- a/examples/appworld/appworld_skill_library_optimization.py
+++ b/examples/appworld/appworld_skill_library_optimization.py
@@ -1,0 +1,264 @@
+"""Example: curate a skill LIBRARY from AppWorld rollout traces.
+
+Optimizes the SET of skills an agent has — which skills should exist at all —
+rather than the wording of a system prompt. An agent reads the rollout traces,
+decides what to create / revise / retire, and the next iteration runs with the
+curated library.
+
+```
+appworld_skill_library_optimization.py             appworld_runtime/  (the deployable runtime)
+  DataLoader(task_ids)                        app.py — AgentCore /invocations entrypoint
+  AgentCoreHTTPRolloutEngine ──HTTP POST──▶      → installs skills_folder, runs the task,
+  (or AgentCoreRolloutEngine, by ARN)              returns {messages, eval_result,
+        │  payload_mapper: {data_sample,params}                skills_applied}
+        ▼            → {task_id, system_prompt, skills_folder, exp_id}
+  AppWorldReward (eval_result.metrics.success → 1.0)
+        │
+  SkillLibraryOptimizer.step()  ← curator agent reads the traces, writes
+        │                          create/ optimize/ retire.txt + manifest.json
+        ▼
+  SkillLibraryFormula.update_params()  → existing − retired + created
+  formula.materialize(...)             → the flat <name>/SKILL.md folder
+```
+
+Compare with ``appworld_agentcore_optimization.py``, which tunes the system prompt
+on the same runtime and the same traces.
+
+Skills are delivered INLINE (``skills_folder`` = ``[{path, content}]``) rather than
+via an S3 pointer, so this needs no bucket and no extra IAM: the skill text travels
+in the payload, which also means a saved trace records exactly what the agent read.
+
+Requires the runtime to be reachable. ``run_example.sh --skills`` builds it, starts
+it, and runs this script against it.
+"""
+
+import json
+import os
+import sys
+
+# The reward and the task loader are identical to the system-prompt example on this
+# runtime -- importing them keeps one definition rather than a copy that can drift.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from appworld_agentcore_optimization import (  # noqa: E402
+    APPWORLD_SYSTEM_PROMPT,
+    AppWorldReward,
+    load_task_samples,
+)
+
+from strands_harness_optimizer.data import DataLoader  # noqa: E402
+from strands_harness_optimizer.formulas import SkillLibraryFormula  # noqa: E402
+from strands_harness_optimizer.optimizers import SkillLibraryOptimizer  # noqa: E402
+from strands_harness_optimizer.rollout_engines import (  # noqa: E402
+    AgentCoreHTTPRolloutEngine,
+    AgentCoreRolloutEngine,
+)
+from strands_harness_optimizer.utils import load_builtin_template  # noqa: E402
+
+OUTPUT_ROOT = os.getenv("SKILL_OUTPUT_ROOT", "./appworld_skill_runs")
+ITERATIONS = int(os.getenv("SKILL_ITERATIONS", "1"))
+OPTIMIZER_MODEL = os.getenv(
+    "SKILL_OPTIMIZER_MODEL", "us.anthropic.claude-sonnet-4-20250514-v1:0"
+)
+# -1 = give the curator every trace. Raise the rollout count and lower this to
+# sample instead (stratified 50/50 success/failure).
+N_SAMPLE_TRACES = int(os.getenv("SKILL_N_SAMPLE_TRACES", "-1"))
+
+
+def pack_inline(skill_dir: str) -> list[dict]:
+    """Pack a materialized skill folder as ``[{"path", "content"}]``.
+
+    Walks the whole tree, so a skill's ``scripts/`` or ``resources/`` travel with
+    it. Raises on a file that is not text rather than skipping it -- a silently
+    dropped resource is a skill that fails at runtime for no visible reason.
+    """
+    out = []
+    for root, _, files in os.walk(skill_dir):
+        for name in sorted(files):
+            full = os.path.join(root, name)
+            rel = os.path.relpath(full, skill_dir)
+            try:
+                with open(full) as f:
+                    out.append({"path": rel, "content": f.read()})
+            except UnicodeDecodeError as e:
+                raise ValueError(
+                    f"{full} is not text and cannot be inlined. Drop it, or deliver "
+                    "this skill set via S3 instead."
+                ) from e
+    return out
+
+
+def make_payload_mapper(skills_ref: dict):
+    """Build a payload_mapper that ships the CURRENT skill set every batch.
+
+    ``skills_ref`` is read at call time, not captured by value: the engine calls
+    ``ensure_sync_params()`` per batch but the mapper is constructed once, so
+    binding the packed skills here would keep sending iteration N-1's library
+    forever -- the run would report iterating while measuring the same thing twice.
+    """
+
+    def mapper(payload: dict) -> dict:
+        data_sample = payload.get("data_sample", {})
+        return {
+            "task_id": data_sample.get("task_id", data_sample.get("id")),
+            # The library is a skills-only intervention, so the prompt stays the
+            # shipped baseline. Sending an optimized prompt too would mix two
+            # surfaces and make the delta unattributable.
+            "system_prompt": APPWORLD_SYSTEM_PROMPT,
+            "skills_folder": skills_ref.get("packed", []),
+            "exp_id": data_sample.get("exp_id", "harness-optimizer-skills"),
+        }
+
+    return mapper
+
+
+def build_engine(formula, skills_ref):
+    """HTTP to a local container, or ARN to a deployed runtime."""
+    base_urls = os.getenv("APPWORLD_BASE_URLS") or os.getenv("APPWORLD_BASE_URL")
+    agent_arn = os.getenv("APPWORLD_AGENT_ARN")
+    if not base_urls and not agent_arn:
+        raise SystemExit(
+            "Set one of:\n"
+            "  APPWORLD_BASE_URL(S)  — local runtime container(s), e.g. 'http://localhost:8080'\n"
+            "                          (comma-separated for a pool of containers)\n"
+            "  APPWORLD_AGENT_ARN    — a deployed AgentCore runtime ARN"
+        )
+    mapper = make_payload_mapper(skills_ref)
+    if base_urls:
+        urls = [u.strip() for u in base_urls.split(",") if u.strip()]
+        print(f"Driving {len(urls)} local runtime container(s) over HTTP: {urls}")
+        return AgentCoreHTTPRolloutEngine(
+            formula=formula,
+            base_urls=urls,
+            num_workers=len(urls),  # one in-flight request per container
+            payload_mapper=mapper,
+        )
+    print("Driving a deployed AgentCore runtime by ARN")
+    return AgentCoreRolloutEngine(
+        formula=formula,
+        agent_arn=agent_arn,
+        region_name=os.getenv("AWS_REGION", "us-west-2"),
+        num_workers=4,
+        payload_mapper=mapper,
+    )
+
+
+def report_activation(rollouts, expected: int) -> None:
+    """Say whether the skills actually LOADED, not just whether they were sent.
+
+    A runtime that predates the ``skills_folder`` key ignores it silently, and the
+    resulting flat reward is indistinguishable from "the skills did not help". The
+    runtime echoes ``skills_applied`` so that case is visible.
+    """
+    if expected == 0:
+        return
+    seen = [r.metadata.get("skills_applied") for r in rollouts]
+    reported = [s for s in seen if s is not None]
+    if not reported:
+        print(
+            "  WARNING no rollout reported `skills_applied` -- the runtime ignored "
+            "`skills_folder`, so this iteration measured the UNCHANGED agent. "
+            "Rebuild the runtime image."
+        )
+    elif all(s == 0 for s in reported):
+        print(f"  WARNING every rollout reported skills_applied=0 of {expected} sent.")
+    else:
+        print(f"  skills loaded in-runtime: {max(reported)} of {expected} sent")
+
+
+def rollout(engine, reward_fn, loader):
+    rollouts, rewards = [], []
+    for batch in loader:
+        for r in engine.generate_batch(batch):
+            rollouts.append(r)
+            rewards.append(reward_fn(r))
+    scored = [w.reward for w in rewards]
+    mean = sum(scored) / len(scored) if scored else 0.0
+    return rollouts, rewards, mean
+
+
+def main():
+    task_samples = load_task_samples()
+    print(f"AppWorld tasks: {len(task_samples)}")
+
+    # Start from whatever library is on disk (SKILL_DIR), or cold -- an empty
+    # library is the normal first iteration, where every action is a CREATE.
+    formula = SkillLibraryFormula(skill_dir=os.getenv("SKILL_DIR") or None)
+    print(f"Starting library: {formula.skill_names or '(empty — cold start)'}")
+
+    # Mutable holder so the payload_mapper always ships the CURRENT set.
+    skills_ref: dict = {"packed": pack_inline(formula.skill_dir) if formula.skill_dir else []}
+
+    engine = build_engine(formula, skills_ref)
+    reward_fn = AppWorldReward()
+    loader = DataLoader(task_samples, batch_size=len(task_samples))
+
+    history = []
+    for it in range(ITERATIONS):
+        print(f"\n{'=' * 60}\n  ITERATION {it}\n{'=' * 60}")
+
+        print(f"[rollout] {len(task_samples)} task(s) with "
+              f"{len(formula.skill_names)} skill(s)")
+        rollouts, rewards, mean = rollout(engine, reward_fn, loader)
+        report_activation(rollouts, len(formula.skill_names))
+        print(f"[rollout] mean reward: {mean:.4f}")
+        history.append({"iteration": it, "skills": list(formula.skill_names),
+                        "mean_reward": mean})
+
+        out_dir = os.path.join(OUTPUT_ROOT, f"iter_{it}")
+        optimizer = SkillLibraryOptimizer(
+            formula,
+            system_prompt_template=load_builtin_template(
+                "skill_library/system_prompt.jinja"),
+            task_message_template=load_builtin_template(
+                "skill_library/task_message.jinja"),
+            output_folder=out_dir,
+            model_config={"model_id": OPTIMIZER_MODEL},
+            n_sample_traces=N_SAMPLE_TRACES,
+        )
+        optimizer.add_rollouts(rollouts)
+        optimizer.add_rewards(rewards)
+
+        print("[curate] running the curator agent ...")
+        optimizer.step()
+        print(f"[curate] decisions: "
+              f"{ {k: len(v) for k, v in optimizer.last_decisions.items()} }")
+
+        if not any(optimizer.last_decisions.values()):
+            # Not a failure. Once the recurring patterns are covered, stopping is
+            # the right move -- the curator says why in manifest.json.
+            print(f"[curate] SKIP — library unchanged; see "
+                  f"{os.path.join(out_dir, 'manifest.json')}")
+            continue
+
+        skill_set = formula.materialize(os.path.join(out_dir, "skill_set"))
+        skills_ref["packed"] = pack_inline(skill_set)
+        print(f"[curate] library now {formula.skill_names}")
+        print(f"[curate] materialized -> {skill_set} "
+              f"({len(skills_ref['packed'])} file(s) inlined)")
+
+    # A final rollout so the last iteration's library is actually measured; without
+    # it the run reports a library nobody ran.
+    print(f"\n{'=' * 60}\n  FINAL EVALUATION\n{'=' * 60}")
+    _, _, final_mean = rollout(engine, reward_fn, loader)
+    history.append({"iteration": "final", "skills": list(formula.skill_names),
+                    "mean_reward": final_mean})
+
+    os.makedirs(OUTPUT_ROOT, exist_ok=True)
+    with open(os.path.join(OUTPUT_ROOT, "history.json"), "w") as f:
+        json.dump(history, f, indent=2)
+
+    print("\nreward by iteration:")
+    for h in history:
+        print(f"  {str(h['iteration']):>5}  {h['mean_reward']:.4f}  "
+              f"({len(h['skills'])} skill(s))")
+    print(f"\nartifacts: {OUTPUT_ROOT}")
+    print(f"final library: {formula.skill_names}")
+    print(
+        f"\n  NOTE {len(task_samples)} task(s), 1 rollout each. A reward delta this "
+        "size is directional at best -- raise the task count and repeat the eval "
+        "before treating it as a result."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/appworld/run_example.sh
+++ b/examples/appworld/run_example.sh
@@ -4,7 +4,7 @@
 # system-prompt optimizer against it (the local-container / HTTP-engine path).
 #
 # Usage:
-#   ./run_example.sh [-f DOCKERFILE] [-s SPLIT] [-t TASK_IDS] [-p PORT] [--build-only] [--no-build]
+#   ./run_example.sh [-f DOCKERFILE] [-s SPLIT] [-t TASK_IDS] [-p PORT] [--skills] [--build-only] [--no-build]
 #
 #   -f  Dockerfile to build (default: appworld_runtime/Dockerfile.amd64 — fully public,
 #       Bedrock, dual venv). Use Dockerfile.arm64 for the arm64 build AgentCore runs.
@@ -12,6 +12,8 @@
 #       The full split is used — extracted as a CSV from the runtime container.
 #   -t  Comma-separated AppWorld task ids to train on a SUBSET instead of the full split.
 #   -p  Host port to publish the runtime on (default: 8080).
+#   --skills       Optimize the SKILL LIBRARY instead of the system prompt
+#                  (runs *_skill_library_optimization.py; skills ship inline in the payload).
 #   --build-only   Build the image and exit.
 #   --no-build     Skip building; assume the image already exists.
 #
@@ -36,6 +38,7 @@ IMAGE="appworld-runtime"
 CONTAINER="appworld-runtime"
 BUILD=1
 RUN_OPTIMIZER=1
+SURFACE="system_prompt"   # --skills switches to the skill-library client
 AWS_REGION="${AWS_REGION:-us-west-2}"
 
 # --- args ---
@@ -45,6 +48,7 @@ while [[ $# -gt 0 ]]; do
     -t) TASK_IDS="$2"; shift 2 ;;      # subset override (comma-separated); else full split
     -s) SPLIT="$2"; shift 2 ;;         # which split to train on (train/dev/test_normal/...)
     -p) PORT="$2"; shift 2 ;;
+    --skills) SURFACE="skills"; shift ;;
     --build-only) RUN_OPTIMIZER=0; shift ;;
     --no-build) BUILD=0; shift ;;
     -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
@@ -157,6 +161,12 @@ else
   echo ">> Training on the full '$SPLIT' split ($n tasks) from $csv_out"
 fi
 
-python3 examples/appworld/appworld_agentcore_optimization.py
+if [[ "$SURFACE" == "skills" ]]; then
+  echo ">> Optimizing the SKILL LIBRARY (AppWorld)"
+  python3 examples/appworld/appworld_skill_library_optimization.py
+else
+  echo ">> Optimizing the SYSTEM PROMPT (AppWorld)"
+  python3 examples/appworld/appworld_agentcore_optimization.py
+fi
 
 echo ">> Done."

--- a/examples/webshop/README.md
+++ b/examples/webshop/README.md
@@ -40,6 +40,7 @@ findings and appends them to the system prompt. This mirrors the internal
 |------|-----------|
 | [`webshop_agentcore_optimization.py`](webshop_agentcore_optimization.py) | The **optimizer** (client). Runs the Trainer loop against the runtime with the multi-agent optimizer. Needs only `strands_harness_optimizer` + a runtime endpoint. |
 | [`webshop_runtime/`](webshop_runtime/) | The **deployable runtime** (container). Builds a Strands + WebShop-gym agent as an AgentCore runtime. See its [README](webshop_runtime/README.md). |
+| [`webshop_skill_library_optimization.py`](webshop_skill_library_optimization.py) | The **skill-library** optimizer (client). Curates the SET of skills the agent has, instead of tuning the system prompt. |
 | [`run_example.sh`](run_example.sh) | One-command driver: build the runtime, start it, wait for health, run the optimizer, clean up. |
 
 ## Quick start (local container)
@@ -83,3 +84,32 @@ WebShop tasks are integer goal indices. A split is a contiguous range:
 
 Set `WEBSHOP_TASK_IDS` for a quick subset, or `WEBSHOP_SPLIT` to train on the whole
 range. The default dataset in the runtime is WebShop's small **1000-product** set.
+
+## Two surfaces on one runtime
+
+The same container serves both optimizers — it applies whatever the payload carries:
+
+| surface | client | what it optimizes | payload key |
+|---|---|---|---|
+| system prompt | `webshop_agentcore_optimization.py` | the prompt text | `system_prompt` |
+| skill library | `webshop_skill_library_optimization.py` | which skills exist (create / revise / retire) | `skills_folder` |
+
+```bash
+./examples/webshop/run_example.sh              # system prompt (default)
+./examples/webshop/run_example.sh --skills     # skill library
+```
+
+Skills travel **inline** in the payload as `[{path, content}]`, not as an S3 pointer,
+so no bucket and no extra IAM are needed — and a saved trace records the skill text the
+agent actually read. Measured skill sets are 8–20 KB, well inside a payload. For a
+library that outgrows that (or carries binary resources), switch to uploading the
+materialized folder and sending a URI instead; `install_skills` in the runtime's
+`_local.py` is the only place that would change.
+
+The runtime echoes `skills_applied` in its response, and the client checks it. That is
+what distinguishes *"the skills did not help"* from *"the skills never loaded"* — a
+runtime built before the `skills_folder` key ignores it silently, and the resulting flat
+reward looks identical to a real null result.
+
+Reward for the curator comes from the same place as the prompt optimizer's:
+`eval_result.metrics.score` — match score in [0,1] (partial credit).

--- a/examples/webshop/run_example.sh
+++ b/examples/webshop/run_example.sh
@@ -4,13 +4,15 @@
 # multi-agent system-prompt optimizer against it (the local-container / HTTP-engine path).
 #
 # Usage:
-#   ./run_example.sh [-f DOCKERFILE] [-s SPLIT] [-t TASK_IDS] [-p PORT] [--build-only] [--no-build]
+#   ./run_example.sh [-f DOCKERFILE] [-s SPLIT] [-t TASK_IDS] [-p PORT] [--skills] [--build-only] [--no-build]
 #
 #   -f  Dockerfile to build (default: webshop_runtime/Dockerfile.amd64 — fully public,
 #       Bedrock, dual venv). Use Dockerfile.arm64 for the arm64 build AgentCore runs.
 #   -s  Split to train on: train (goal indices 0-99) / eval (0-199). Default: train.
 #   -t  Comma-separated WebShop task ids (goal indices) to train on a SUBSET instead.
 #   -p  Host port to publish the runtime on (default: 8080).
+#   --skills       Optimize the SKILL LIBRARY instead of the system prompt
+#                  (runs *_skill_library_optimization.py; skills ship inline in the payload).
 #   --build-only   Build the image and exit.
 #   --no-build     Skip building; assume the image already exists.
 #
@@ -34,6 +36,7 @@ IMAGE="webshop-runtime"
 CONTAINER="webshop-runtime"
 BUILD=1
 RUN_OPTIMIZER=1
+SURFACE="system_prompt"   # --skills switches to the skill-library client
 AWS_REGION="${AWS_REGION:-us-west-2}"
 
 # --- args ---
@@ -43,6 +46,7 @@ while [[ $# -gt 0 ]]; do
     -t) TASK_IDS="$2"; shift 2 ;;      # subset override (comma-separated); else full split
     -s) SPLIT="$2"; shift 2 ;;         # which split to train on (train/eval)
     -p) PORT="$2"; shift 2 ;;
+    --skills) SURFACE="skills"; shift ;;
     --build-only) RUN_OPTIMIZER=0; shift ;;
     --no-build) BUILD=0; shift ;;
     -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
@@ -144,6 +148,12 @@ else
   echo ">> Training on the full '$SPLIT' split range"
 fi
 
-python3 examples/webshop/webshop_agentcore_optimization.py
+if [[ "$SURFACE" == "skills" ]]; then
+  echo ">> Optimizing the SKILL LIBRARY (WebShop)"
+  python3 examples/webshop/webshop_skill_library_optimization.py
+else
+  echo ">> Optimizing the SYSTEM PROMPT (WebShop)"
+  python3 examples/webshop/webshop_agentcore_optimization.py
+fi
 
 echo ">> Done."

--- a/examples/webshop/webshop_runtime/_local.py
+++ b/examples/webshop/webshop_runtime/_local.py
@@ -1,4 +1,4 @@
-"""Self-contained helpers for the AppWorld runtime example.
+"""Self-contained helpers for the WebShop runtime example.
 
 These are the few small utilities the runtime needs that would otherwise come
 from the internal ``agent_customizer`` package. They are reproduced here (with
@@ -6,10 +6,12 @@ no ``agent_customizer`` dependency) so this example depends only on
 ``strands_harness_optimizer`` + ``strands`` + the ``appworld`` package:
 
 - ``make_eval_result`` — the plain-dict eval-result shape the reward reads.
-- ``ManagedProcess``   — start/stop a subprocess (the AppWorld env server),
+- ``ManagedProcess``   — start/stop a subprocess (the WebShop env server),
   waiting for a readiness line and draining stdout so its pipe never fills.
 - ``create_strands_agent`` — build a Strands ``Agent`` (Bedrock or an
   OpenAI-compatible endpoint) with MCP + extra tools and a bounded window.
+- ``install_skills`` — materialize an inline ``skills_folder`` payload onto disk
+  and (re)attach the ``AgentSkills`` plugin, for skill-library optimization.
 """
 
 import logging
@@ -136,11 +138,16 @@ def create_strands_agent(
     model_config: Dict[str, Any],
     mcp_client: Optional[Any] = None,
     additional_tools: Optional[List] = None,
+    plugins: Optional[List] = None,
 ) -> Any:
     """Create a Strands Agent (bedrock | openai) with MCP + extra tools.
 
     Provider is chosen explicitly by ``model_config['provider']`` — no inference
     and no fallback between providers; missing required fields raise.
+
+    ``plugins`` is passed straight to ``Agent(plugins=...)``. It exists so a
+    runtime can attach ``AgentSkills`` (skill optimization); ``None`` keeps the
+    previous behaviour exactly.
     """
     from strands import Agent
     from strands.agent.conversation_manager import SlidingWindowConversationManager
@@ -212,11 +219,120 @@ def create_strands_agent(
         window_size=model_config.get("conversation_window_size", 40),
         should_truncate_results=True,
     )
-    agent = Agent(
+    agent_kwargs = dict(
         model=model,
         system_prompt=model_config.get("initial_prompt", ""),
         tools=tools,
         conversation_manager=conversation_manager,
     )
-    logger.info("Created Strands agent with %d total tools", len(tools))
+    # Only pass `plugins` when there are some: an older strands may not accept the
+    # kwarg at all, and every existing caller passes None.
+    if plugins:
+        agent_kwargs["plugins"] = plugins
+    agent = Agent(**agent_kwargs)
+    logger.info(
+        "Created Strands agent with %d total tools and %d plugin(s)",
+        len(tools),
+        len(plugins or []),
+    )
     return agent
+
+
+# --- skills (skill-library optimization) --------------------------------------
+
+SKILLS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_skills")
+
+
+def install_skills(agent: Any, skills_folder: Optional[List[Dict[str, str]]]) -> int:
+    """Write an inline skills payload to disk and (re)attach ``AgentSkills``.
+
+    ``skills_folder`` is the wire shape the skill-library optimizer sends:
+    ``[{"path": "<name>/SKILL.md", "content": "..."}, ...]``. Skills travel INSIDE
+    the payload rather than as an S3 pointer, so the runtime needs no bucket and
+    no credentials beyond what it already has, and a saved trace records the skill
+    text that actually ran.
+
+    The plugin is REBUILT on every call rather than mutated. ``AgentSkills`` reads
+    a filesystem path once, at ``init_agent`` time, so rewriting the folder under a
+    live plugin would not change what the agent sees -- the optimizer's new skills
+    would silently never load, which is indistinguishable from "the skills did not
+    help".
+
+    Returns the number of skills installed (0 clears them).
+    """
+    import shutil
+
+    from strands import AgentSkills
+
+    # Fresh directory each time: a skill the optimizer RETIRED must disappear, and
+    # leaving it on disk would keep it loadable.
+    shutil.rmtree(SKILLS_DIR, ignore_errors=True)
+    os.makedirs(SKILLS_DIR, exist_ok=True)
+
+    for item in skills_folder or []:
+        rel = str(item.get("path") or "").lstrip("/")
+        if not rel or ".." in rel.split("/"):
+            logger.warning("skipping suspicious skills_folder path %r", rel)
+            continue
+        dest = os.path.join(SKILLS_DIR, rel)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "w") as f:
+            f.write(item.get("content") or "")
+
+    names = sorted(
+        d for d in os.listdir(SKILLS_DIR)
+        if os.path.isfile(os.path.join(SKILLS_DIR, d, "SKILL.md"))
+    )
+
+    registry = getattr(agent, "_plugin_registry", None)
+    plugins = getattr(registry, "_plugins", None)
+    if plugins is None:
+        logger.warning("agent has no plugin registry; cannot install skills")
+        return 0
+
+    # Drop any previously-installed AgentSkills before adding the new one.
+    existing = plugins.get("agent_skills")
+    if existing is not None:
+        del plugins["agent_skills"]
+
+    if not names:
+        logger.info("skills cleared (no skills in payload)")
+        return 0
+
+    plugin = AgentSkills(skills=SKILLS_DIR)
+    registry.add_and_init(plugin)
+
+    # Report what the AGENT can see, not merely what we wrote: a skill whose
+    # frontmatter is damaged is written but never loadable, and counting files would
+    # call that a success.
+    #
+    # Filesystem skills are resolved per-agent during init_agent, so the resolved
+    # set is only reachable by passing the agent -- and that parameter exists in
+    # newer strands only (1.47 `get_available_skills(self, agent=None)`, 1.33
+    # `get_available_skills(self)`). On the older signature the return value is the
+    # construction-time list, which is EMPTY for a directory-loaded plugin, so it
+    # cannot be used to verify anything; fall back to the files written rather than
+    # reporting a spurious zero.
+    verified = True
+    try:
+        loaded = [s.name for s in plugin.get_available_skills(agent)]
+    except TypeError:
+        loaded, verified = names, False
+
+    if not verified:
+        logger.info(
+            "installed %d skill(s): %s (file count -- this strands version cannot "
+            "report the agent's resolved set, so a skill with damaged frontmatter "
+            "would not be caught here)",
+            len(loaded), ", ".join(sorted(loaded)),
+        )
+    elif len(loaded) != len(names):
+        logger.warning(
+            "wrote %d skill(s) %s but the agent resolved %d %s -- the difference "
+            "could not be loaded (check YAML frontmatter: `name:` and "
+            "`description:` are required)",
+            len(names), names, len(loaded), loaded,
+        )
+    else:
+        logger.info("installed %d skill(s): %s", len(loaded), ", ".join(sorted(loaded)))
+    return len(loaded)

--- a/examples/webshop/webshop_runtime/app.py
+++ b/examples/webshop/webshop_runtime/app.py
@@ -58,7 +58,7 @@ print("Agent Starting")
 
 os.environ["BYPASS_TOOL_CONSENT"] = BYPASS_TOOL_CONSENT
 
-from _local import create_strands_agent
+from _local import create_strands_agent, install_skills
 from dataset import WebShopDataset, WebShopEnvironment
 
 logger.info(f"Creating WebShop dataset (split={DATASET_SPLIT}, task_ids={TASK_IDS})")
@@ -135,6 +135,14 @@ def invoke(payload):
     processor_system_prompt = payload.get("system_prompt", system_prompt)
     processor.update_params({"system_prompt": processor_system_prompt})
 
+    # Skill-library optimization: the optimizer ships its current skill set INLINE
+    # as [{path, content}]. Absent the key nothing changes, so a prompt-only run is
+    # unaffected. Installed per invocation because the set changes between
+    # iterations, and AgentSkills reads its folder only at plugin-init time.
+    n_skills = 0
+    if "skills_folder" in payload:
+        n_skills = install_skills(agent, payload.get("skills_folder"))
+
     # Extract payload parameters.
     task_id = payload.get("task_id")
     exp_id = payload.get("exp_id", "default")
@@ -163,6 +171,10 @@ def invoke(payload):
         "messages": adapter.extract_context(agent)["messages"],
         "stop_reason": None,
         "eval_result": eval_result,
+        # Echoed so the client can tell "the skills did not help" apart from "the
+        # skills never loaded" -- a runtime that predates the payload key ignores
+        # it silently, and the resulting null delta looks identical to a real one.
+        "skills_applied": n_skills,
     }
 
 

--- a/examples/webshop/webshop_skill_library_optimization.py
+++ b/examples/webshop/webshop_skill_library_optimization.py
@@ -1,0 +1,264 @@
+"""Example: curate a skill LIBRARY from WebShop rollout traces.
+
+Optimizes the SET of skills an agent has — which skills should exist at all —
+rather than the wording of a system prompt. An agent reads the rollout traces,
+decides what to create / revise / retire, and the next iteration runs with the
+curated library.
+
+```
+webshop_skill_library_optimization.py             webshop_runtime/  (the deployable runtime)
+  DataLoader(task_ids)                        app.py — AgentCore /invocations entrypoint
+  AgentCoreHTTPRolloutEngine ──HTTP POST──▶      → installs skills_folder, runs the task,
+  (or AgentCoreRolloutEngine, by ARN)              returns {messages, eval_result,
+        │  payload_mapper: {data_sample,params}                skills_applied}
+        ▼            → {task_id, system_prompt, skills_folder, exp_id}
+  WebShopReward   (eval_result.metrics.score, partial credit in [0,1])
+        │
+  SkillLibraryOptimizer.step()  ← curator agent reads the traces, writes
+        │                          create/ optimize/ retire.txt + manifest.json
+        ▼
+  SkillLibraryFormula.update_params()  → existing − retired + created
+  formula.materialize(...)             → the flat <name>/SKILL.md folder
+```
+
+Compare with ``webshop_agentcore_optimization.py``, which tunes the system prompt
+on the same runtime and the same traces.
+
+Skills are delivered INLINE (``skills_folder`` = ``[{path, content}]``) rather than
+via an S3 pointer, so this needs no bucket and no extra IAM: the skill text travels
+in the payload, which also means a saved trace records exactly what the agent read.
+
+Requires the runtime to be reachable. ``run_example.sh --skills`` builds it, starts
+it, and runs this script against it.
+"""
+
+import json
+import os
+import sys
+
+# The reward and the task loader are identical to the system-prompt example on this
+# runtime -- importing them keeps one definition rather than a copy that can drift.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from webshop_agentcore_optimization import (  # noqa: E402
+    WEBSHOP_SYSTEM_PROMPT,
+    WebShopReward,
+    load_task_samples,
+)
+
+from strands_harness_optimizer.data import DataLoader  # noqa: E402
+from strands_harness_optimizer.formulas import SkillLibraryFormula  # noqa: E402
+from strands_harness_optimizer.optimizers import SkillLibraryOptimizer  # noqa: E402
+from strands_harness_optimizer.rollout_engines import (  # noqa: E402
+    AgentCoreHTTPRolloutEngine,
+    AgentCoreRolloutEngine,
+)
+from strands_harness_optimizer.utils import load_builtin_template  # noqa: E402
+
+OUTPUT_ROOT = os.getenv("SKILL_OUTPUT_ROOT", "./webshop_skill_runs")
+ITERATIONS = int(os.getenv("SKILL_ITERATIONS", "1"))
+OPTIMIZER_MODEL = os.getenv(
+    "SKILL_OPTIMIZER_MODEL", "us.anthropic.claude-sonnet-4-20250514-v1:0"
+)
+# -1 = give the curator every trace. Raise the rollout count and lower this to
+# sample instead (stratified 50/50 success/failure).
+N_SAMPLE_TRACES = int(os.getenv("SKILL_N_SAMPLE_TRACES", "-1"))
+
+
+def pack_inline(skill_dir: str) -> list[dict]:
+    """Pack a materialized skill folder as ``[{"path", "content"}]``.
+
+    Walks the whole tree, so a skill's ``scripts/`` or ``resources/`` travel with
+    it. Raises on a file that is not text rather than skipping it -- a silently
+    dropped resource is a skill that fails at runtime for no visible reason.
+    """
+    out = []
+    for root, _, files in os.walk(skill_dir):
+        for name in sorted(files):
+            full = os.path.join(root, name)
+            rel = os.path.relpath(full, skill_dir)
+            try:
+                with open(full) as f:
+                    out.append({"path": rel, "content": f.read()})
+            except UnicodeDecodeError as e:
+                raise ValueError(
+                    f"{full} is not text and cannot be inlined. Drop it, or deliver "
+                    "this skill set via S3 instead."
+                ) from e
+    return out
+
+
+def make_payload_mapper(skills_ref: dict):
+    """Build a payload_mapper that ships the CURRENT skill set every batch.
+
+    ``skills_ref`` is read at call time, not captured by value: the engine calls
+    ``ensure_sync_params()`` per batch but the mapper is constructed once, so
+    binding the packed skills here would keep sending iteration N-1's library
+    forever -- the run would report iterating while measuring the same thing twice.
+    """
+
+    def mapper(payload: dict) -> dict:
+        data_sample = payload.get("data_sample", {})
+        return {
+            "task_id": data_sample.get("task_id", data_sample.get("id")),
+            # The library is a skills-only intervention, so the prompt stays the
+            # shipped baseline. Sending an optimized prompt too would mix two
+            # surfaces and make the delta unattributable.
+            "system_prompt": WEBSHOP_SYSTEM_PROMPT,
+            "skills_folder": skills_ref.get("packed", []),
+            "exp_id": data_sample.get("exp_id", "harness-optimizer-skills"),
+        }
+
+    return mapper
+
+
+def build_engine(formula, skills_ref):
+    """HTTP to a local container, or ARN to a deployed runtime."""
+    base_urls = os.getenv("WEBSHOP_BASE_URLS") or os.getenv("WEBSHOP_BASE_URL")
+    agent_arn = os.getenv("WEBSHOP_AGENT_ARN")
+    if not base_urls and not agent_arn:
+        raise SystemExit(
+            "Set one of:\n"
+            "  WEBSHOP_BASE_URL(S)  — local runtime container(s), e.g. 'http://localhost:8080'\n"
+            "                          (comma-separated for a pool of containers)\n"
+            "  WEBSHOP_AGENT_ARN    — a deployed AgentCore runtime ARN"
+        )
+    mapper = make_payload_mapper(skills_ref)
+    if base_urls:
+        urls = [u.strip() for u in base_urls.split(",") if u.strip()]
+        print(f"Driving {len(urls)} local runtime container(s) over HTTP: {urls}")
+        return AgentCoreHTTPRolloutEngine(
+            formula=formula,
+            base_urls=urls,
+            num_workers=len(urls),  # one in-flight request per container
+            payload_mapper=mapper,
+        )
+    print("Driving a deployed AgentCore runtime by ARN")
+    return AgentCoreRolloutEngine(
+        formula=formula,
+        agent_arn=agent_arn,
+        region_name=os.getenv("AWS_REGION", "us-west-2"),
+        num_workers=4,
+        payload_mapper=mapper,
+    )
+
+
+def report_activation(rollouts, expected: int) -> None:
+    """Say whether the skills actually LOADED, not just whether they were sent.
+
+    A runtime that predates the ``skills_folder`` key ignores it silently, and the
+    resulting flat reward is indistinguishable from "the skills did not help". The
+    runtime echoes ``skills_applied`` so that case is visible.
+    """
+    if expected == 0:
+        return
+    seen = [r.metadata.get("skills_applied") for r in rollouts]
+    reported = [s for s in seen if s is not None]
+    if not reported:
+        print(
+            "  WARNING no rollout reported `skills_applied` -- the runtime ignored "
+            "`skills_folder`, so this iteration measured the UNCHANGED agent. "
+            "Rebuild the runtime image."
+        )
+    elif all(s == 0 for s in reported):
+        print(f"  WARNING every rollout reported skills_applied=0 of {expected} sent.")
+    else:
+        print(f"  skills loaded in-runtime: {max(reported)} of {expected} sent")
+
+
+def rollout(engine, reward_fn, loader):
+    rollouts, rewards = [], []
+    for batch in loader:
+        for r in engine.generate_batch(batch):
+            rollouts.append(r)
+            rewards.append(reward_fn(r))
+    scored = [w.reward for w in rewards]
+    mean = sum(scored) / len(scored) if scored else 0.0
+    return rollouts, rewards, mean
+
+
+def main():
+    task_samples = load_task_samples()
+    print(f"WebShop tasks: {len(task_samples)}")
+
+    # Start from whatever library is on disk (SKILL_DIR), or cold -- an empty
+    # library is the normal first iteration, where every action is a CREATE.
+    formula = SkillLibraryFormula(skill_dir=os.getenv("SKILL_DIR") or None)
+    print(f"Starting library: {formula.skill_names or '(empty — cold start)'}")
+
+    # Mutable holder so the payload_mapper always ships the CURRENT set.
+    skills_ref: dict = {"packed": pack_inline(formula.skill_dir) if formula.skill_dir else []}
+
+    engine = build_engine(formula, skills_ref)
+    reward_fn = WebShopReward()
+    loader = DataLoader(task_samples, batch_size=len(task_samples))
+
+    history = []
+    for it in range(ITERATIONS):
+        print(f"\n{'=' * 60}\n  ITERATION {it}\n{'=' * 60}")
+
+        print(f"[rollout] {len(task_samples)} task(s) with "
+              f"{len(formula.skill_names)} skill(s)")
+        rollouts, rewards, mean = rollout(engine, reward_fn, loader)
+        report_activation(rollouts, len(formula.skill_names))
+        print(f"[rollout] mean reward: {mean:.4f}")
+        history.append({"iteration": it, "skills": list(formula.skill_names),
+                        "mean_reward": mean})
+
+        out_dir = os.path.join(OUTPUT_ROOT, f"iter_{it}")
+        optimizer = SkillLibraryOptimizer(
+            formula,
+            system_prompt_template=load_builtin_template(
+                "skill_library/system_prompt.jinja"),
+            task_message_template=load_builtin_template(
+                "skill_library/task_message.jinja"),
+            output_folder=out_dir,
+            model_config={"model_id": OPTIMIZER_MODEL},
+            n_sample_traces=N_SAMPLE_TRACES,
+        )
+        optimizer.add_rollouts(rollouts)
+        optimizer.add_rewards(rewards)
+
+        print("[curate] running the curator agent ...")
+        optimizer.step()
+        print(f"[curate] decisions: "
+              f"{ {k: len(v) for k, v in optimizer.last_decisions.items()} }")
+
+        if not any(optimizer.last_decisions.values()):
+            # Not a failure. Once the recurring patterns are covered, stopping is
+            # the right move -- the curator says why in manifest.json.
+            print(f"[curate] SKIP — library unchanged; see "
+                  f"{os.path.join(out_dir, 'manifest.json')}")
+            continue
+
+        skill_set = formula.materialize(os.path.join(out_dir, "skill_set"))
+        skills_ref["packed"] = pack_inline(skill_set)
+        print(f"[curate] library now {formula.skill_names}")
+        print(f"[curate] materialized -> {skill_set} "
+              f"({len(skills_ref['packed'])} file(s) inlined)")
+
+    # A final rollout so the last iteration's library is actually measured; without
+    # it the run reports a library nobody ran.
+    print(f"\n{'=' * 60}\n  FINAL EVALUATION\n{'=' * 60}")
+    _, _, final_mean = rollout(engine, reward_fn, loader)
+    history.append({"iteration": "final", "skills": list(formula.skill_names),
+                    "mean_reward": final_mean})
+
+    os.makedirs(OUTPUT_ROOT, exist_ok=True)
+    with open(os.path.join(OUTPUT_ROOT, "history.json"), "w") as f:
+        json.dump(history, f, indent=2)
+
+    print("\nreward by iteration:")
+    for h in history:
+        print(f"  {str(h['iteration']):>5}  {h['mean_reward']:.4f}  "
+              f"({len(h['skills'])} skill(s))")
+    print(f"\nartifacts: {OUTPUT_ROOT}")
+    print(f"final library: {formula.skill_names}")
+    print(
+        f"\n  NOTE {len(task_samples)} task(s), 1 rollout each. A reward delta this "
+        "size is directional at best -- raise the task count and repeat the eval "
+        "before treating it as a result."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/strands_harness_optimizer/formulas/__init__.py
+++ b/strands_harness_optimizer/formulas/__init__.py
@@ -3,6 +3,13 @@
 from .context_expansion_formula import ContextExpansionFormula
 from .formula import Formula
 from .skill_formula import SkillFormula
+from .skill_library_formula import SkillLibraryFormula
 from .system_prompt_formula import SystemPromptFormula
 
-__all__ = ["Formula", "SystemPromptFormula", "ContextExpansionFormula", "SkillFormula"]
+__all__ = [
+    "Formula",
+    "SystemPromptFormula",
+    "ContextExpansionFormula",
+    "SkillFormula",
+    "SkillLibraryFormula",
+]

--- a/strands_harness_optimizer/formulas/skill_library_formula.py
+++ b/strands_harness_optimizer/formulas/skill_library_formula.py
@@ -1,0 +1,427 @@
+"""
+Built-in formula for optimizing a whole Strands Agent Skill *library*.
+
+Where :class:`~strands_harness_optimizer.formulas.SkillFormula` tunes the text of
+ONE skill, ``SkillLibraryFormula`` owns a **library** of skills and lets an optimizer
+change its membership: create a skill that does not exist, revise one that does,
+retire one that hurts. That is a diff over a set, not a value to overwrite, and it
+is why the tunable parameter here is a *directory* rather than the skill text.
+
+A skill is a DIRECTORY (``<name>/SKILL.md``, plus any ``scripts/`` or
+``resources/`` it needs), so the directory is the unit this formula manages:
+
+    skill_dir/
+      web-search/SKILL.md
+      checkout/SKILL.md
+
+``get_tunable_params`` therefore returns ``{"skill_dir": "<path>"}``. The optimizer
+does not rewrite that string — it writes a DECISION TREE and calls
+``update_params`` with the folder it wrote to; see :meth:`update_params`.
+
+Frontmatter is validated on the way in. A ``SKILL.md`` without a YAML
+``description:`` can never be loaded by the runtime, so accepting one would spend a
+whole evaluation to measure nothing — the skill would simply never fire, which is
+indistinguishable from "the skill did not help".
+"""
+
+import logging
+import os
+import shutil
+from typing import TYPE_CHECKING, Optional
+
+from strands.hooks.events import BeforeInvocationEvent
+
+from .formula import Formula
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from strands import Skill
+
+logger = logging.getLogger(__name__)
+
+# Written by the optimizer agent, read by _collect_decisions.
+CREATE_DIRS = ("create", "deploy")  # "deploy" accepted as a legacy alias
+OPTIMIZE_DIR = "optimize"
+RETIRE_FILE = "retire.txt"
+MANIFEST_FILE = "manifest.json"
+
+SKILL_FILE = "SKILL.md"
+# Bound on how far to read looking for the closing `---`. Frontmatter is metadata;
+# anything beyond this is the body.
+_FRONTMATTER_MAX_BYTES = 8000
+
+
+class SkillLibraryFormula(Formula):
+    """Formula that manages a *set* of Strands Skills as a tunable directory.
+
+    The tunable parameter is the skill directory, not the skill text::
+
+        formula.get_tunable_params()      # {'skill_dir': '/path/to/skills'}
+
+    An optimizer changes the set by writing a decision tree and handing back the
+    folder it wrote to::
+
+        formula.update_params({"decisions_dir": "/path/to/optimizer/output"})
+
+    which is resolved as ``existing - retired - optimized_old + created``.
+
+    Example:
+        from strands import Agent, AgentSkills
+
+        formula = SkillLibraryFormula(skill_dir="./skills")     # or None for a cold start
+
+        # in-process agents: the adapter pushes the set into AgentSkills
+        agent = Agent(plugins=[AgentSkills(skills=[])])
+        apply_formulas_on_strands_agent(agent, [formula])
+
+        # remote agents: materialize, then deliver the folder yourself
+        formula.materialize("./optimized_skills")
+
+    Args:
+        skill_dir: Directory holding the starting skill set, as
+            ``<skill_dir>/<name>/SKILL.md``. ``None`` or a missing path means a
+            COLD START — an empty library, which is a normal first iteration.
+        strict: If True, a skill whose frontmatter is unusable raises instead of
+            being skipped with a warning. Off by default so one damaged skill in a
+            starting set cannot abort a run.
+    """
+
+    def __init__(self, skill_dir: Optional[str] = None, strict: bool = False):
+        super().__init__("skill_library_formula", [BeforeInvocationEvent])
+        self.strict = strict
+        # name -> directory holding that skill. The values are absolute paths that
+        # may live outside skill_dir: an optimized skill is read straight from the
+        # optimizer's output folder until materialize() collects the set.
+        self.members: dict[str, str] = {}
+        self.skill_dir = skill_dir
+        if skill_dir:
+            self.members = _load_skill_dirs(skill_dir, strict=strict)
+            logger.info(
+                "SkillLibraryFormula: loaded %d skill(s) from %s", len(self.members), skill_dir
+            )
+        else:
+            logger.info("SkillLibraryFormula: cold start, no skills deployed")
+
+    # ── Formula protocol ─────────────────────────────────────────────────────
+    def process(self, context: dict, **kwargs) -> dict:
+        """Hand the current set to the adapter, for IN-PROCESS agents.
+
+        Returns the skills under the ``"skills"`` key; ``StrandsAdapter`` pushes
+        them into the agent's ``AgentSkills`` plugin via ``set_available_skills()``.
+
+        ``Skill`` objects are rebuilt from disk on every invocation rather than
+        cached. ``AgentSkills`` reads a filesystem path once, at ``init_agent``
+        time, so a folder rewritten mid-run would NOT reach a live agent; passing
+        freshly-loaded objects is what makes an optimizer update take effect.
+
+        Remote agents never call this — they receive the set through the payload
+        (see :meth:`materialize`), and their own container-side plugin loads it.
+        """
+        if not self.members:
+            # Cold start. Returning {"skills": []} would CLEAR a plugin that was
+            # constructed with skills of its own, so leave the context untouched.
+            return context
+        skills = self._load_skills()
+        if not skills:
+            return context
+        return {"skills": skills}
+
+    def get_tunable_params(self) -> dict:
+        """Return the skill directory as the tunable parameter.
+
+        A directory, not the skill text: a skill is a tree of files, and the set's
+        membership is itself what gets optimized. Both are outside what a
+        ``{name: text}`` mapping can express.
+        """
+        return {"skill_dir": self.skill_dir or ""}
+
+    def update_params(self, params: dict) -> None:
+        """Apply the optimizer's decisions to the set.
+
+        Accepts either form:
+
+        ``{"decisions_dir": "<folder>"}``
+            The folder an optimizer agent wrote, holding ``create/<name>/``,
+            ``optimize/<name>/`` and ``retire.txt``. Resolved as
+            ``existing - retired - optimized_old + created``.
+
+        ``{"skill_dir": "<folder>"}``
+            Replace the set wholesale from an already-resolved flat folder. Used
+            when restoring a checkpoint rather than applying a step.
+
+        Skills whose frontmatter cannot be loaded are REJECTED here rather than at
+        evaluation time — the runtime keys on the frontmatter ``description`` to
+        decide whether to load a skill, so a malformed one silently never fires.
+        """
+        if "skill_dir" in params and "decisions_dir" not in params:
+            new_dir = params["skill_dir"] or None
+            self.skill_dir = new_dir
+            self.members = _load_skill_dirs(new_dir, strict=self.strict) if new_dir else {}
+            logger.info(
+                "SkillLibraryFormula: set replaced from %s (%d skill(s))",
+                new_dir,
+                len(self.members),
+            )
+            return
+
+        decisions_dir = params.get("decisions_dir")
+        if not decisions_dir:
+            raise ValueError(
+                "SkillLibraryFormula.update_params needs 'decisions_dir' (a folder with "
+                "create/, optimize/ and/or retire.txt) or 'skill_dir' (an "
+                f"already-resolved flat skill folder). Got keys: {sorted(params)}"
+            )
+
+        decisions = collect_decisions(decisions_dir)
+        added, modified, removed = self._apply_decisions(decisions)
+        logger.info(
+            "SkillLibraryFormula: +%d ~%d -%d -> %d skill(s)",
+            len(added),
+            len(modified),
+            len(removed),
+            len(self.members),
+        )
+
+    # ── set algebra ──────────────────────────────────────────────────────────
+    def _apply_decisions(self, decisions: dict) -> tuple[list, list, list]:
+        """``existing - retired - optimized_old + created``.
+
+        MERGE and SPLIT need no cases of their own: both are written as a create
+        plus a retire of every source, so they resolve through the same algebra.
+        """
+        added: list[str] = []
+        modified: list[str] = []
+        removed: list[str] = []
+
+        for name in decisions.get("retire", []):
+            if self.members.pop(name, None) is not None:
+                removed.append(name)
+            else:
+                # Not fatal, but it means the optimizer's view of the library
+                # disagreed with ours -- worth saying out loud.
+                logger.warning(
+                    "retire %r: not in the current set, ignored (known: %s)",
+                    name,
+                    sorted(self.members),
+                )
+
+        for path in decisions.get("optimize", []):
+            name = os.path.basename(os.path.normpath(path))
+            if not self._accept(name, path):
+                continue
+            self.members[name] = path
+            modified.append(name)
+
+        for path in decisions.get("create", []):
+            name = os.path.basename(os.path.normpath(path))
+            if not self._accept(name, path):
+                continue
+            # A "create" naming a deployed skill is a revision in practice; record
+            # it as one so the counts describe what happened.
+            if name in self.members:
+                modified.append(name)
+            else:
+                added.append(name)
+            self.members[name] = path
+
+        return added, modified, removed
+
+    def _accept(self, name: str, path: str) -> bool:
+        """Gate a skill on loadable frontmatter, before it enters the set."""
+        problems = validate_skill_dir(path)
+        if not problems:
+            return True
+        msg = f"rejecting skill {name!r} at {path}: " + "; ".join(problems)
+        if self.strict:
+            raise ValueError(msg)
+        logger.warning("%s", msg)
+        return False
+
+    # ── artifact ─────────────────────────────────────────────────────────────
+    def materialize(self, out_dir: str) -> str:
+        """Write the resolved set to ``out_dir`` as a flat ``<name>/SKILL.md`` tree.
+
+        The optimizer's output is a set of DECISIONS (``create/``, ``optimize/``,
+        ``retire.txt``), and members may still point into it. This collects them
+        into the one flat folder an agent can actually load, and repoints
+        ``skill_dir`` at it.
+
+        Copies whole trees, so a skill carrying ``scripts/`` or ``resources/``
+        survives intact.
+
+        Delivering that folder to a REMOTE agent (uploading it, or packing it into
+        a payload) is deliberately not done here: it needs a bucket, credentials
+        and a transport this library has no business assuming. See the skills
+        example for helpers.
+
+        Returns:
+            The path written (``out_dir``).
+        """
+        os.makedirs(out_dir, exist_ok=True)
+        for name, src in sorted(self.members.items()):
+            dest = os.path.join(out_dir, name)
+            # A second materialize() to the same folder would otherwise delete the
+            # destination and then copy FROM it: the first call repoints members at
+            # out_dir, so src and dest are the same directory.
+            if os.path.realpath(src) == os.path.realpath(dest):
+                continue
+            if os.path.exists(dest):
+                shutil.rmtree(dest)
+            shutil.copytree(src, dest)
+        self.skill_dir = out_dir
+        self.members = {n: os.path.join(out_dir, n) for n in self.members}
+        logger.info(
+            "SkillLibraryFormula: materialized %d skill(s) -> %s", len(self.members), out_dir
+        )
+        return out_dir
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+    def _load_skills(self) -> list["Skill"]:
+        """Build ``Skill`` objects for the current set, skipping unloadable ones."""
+        from strands import Skill
+
+        out = []
+        for name, path in sorted(self.members.items()):
+            try:
+                out.append(Skill.from_file(path))
+            except Exception as e:  # noqa: BLE001 - a bad skill must not kill the run
+                logger.warning("skill %r at %s could not be loaded: %s", name, path, e)
+        return out
+
+    @property
+    def skill_names(self) -> list[str]:
+        """Names in the current set."""
+        return sorted(self.members)
+
+
+# ── module-level helpers (shared with the optimizer) ─────────────────────────
+
+
+def collect_decisions(out_dir: str) -> dict:
+    """Read an optimizer agent's decision tree off disk.
+
+    Returns ``{"create": [paths], "optimize": [paths], "retire": [names]}``.
+    Presence on disk is the source of truth — not what the agent said it did — so
+    a write that silently failed cannot be recorded as a change.
+    """
+    out: dict = {"create": [], "optimize": [], "retire": []}
+    for folder in CREATE_DIRS:
+        d = os.path.join(out_dir, folder)
+        if os.path.isdir(d):
+            out["create"] = skill_dirs_in(d)
+            break
+    d = os.path.join(out_dir, OPTIMIZE_DIR)
+    if os.path.isdir(d):
+        out["optimize"] = skill_dirs_in(d)
+    f = os.path.join(out_dir, RETIRE_FILE)
+    if os.path.isfile(f):
+        with open(f) as fh:
+            out["retire"] = [ln.strip() for ln in fh if ln.strip()]
+    return out
+
+
+def skill_dirs_in(root: str) -> list[str]:
+    """Directories containing a ``SKILL.md``, at either depth.
+
+    ``root`` itself may be the skill (``<root>/SKILL.md``) or a parent of several.
+    """
+    if not os.path.isdir(root):
+        return []
+    if os.path.isfile(os.path.join(root, SKILL_FILE)):
+        return [root]
+    out = []
+    for entry in sorted(os.listdir(root)):
+        p = os.path.join(root, entry)
+        if os.path.isdir(p) and os.path.isfile(os.path.join(p, SKILL_FILE)):
+            out.append(p)
+    return out
+
+
+def read_frontmatter(skill_md: str) -> str:
+    """Return the leading ``---`` block, however long its values are.
+
+    Read up to the closing delimiter rather than a fixed number of characters: a
+    legitimate multi-line ``description:`` easily overruns a guessed window, and
+    the closing ``---`` then falls outside it — reporting a VALID skill as missing
+    its keys, which would drop a correct artifact.
+    """
+    with open(skill_md, encoding="utf-8", errors="replace") as f:
+        text = f.read(_FRONTMATTER_MAX_BYTES)
+    stripped = text.lstrip()
+    if not stripped.startswith("---"):
+        return ""
+    body = stripped[3:]
+    end = body.find("\n---")
+    return body if end == -1 else body[:end]
+
+
+def validate_skill_dir(path: str) -> list[str]:
+    """Structural checks a skill must pass to be loadable at runtime.
+
+    Returns a list of problems; empty means usable. ``description`` is the field
+    the runtime matches on to decide whether to load a skill, so a skill missing
+    it can never fire — an expensive silent no-op, hence a hard reject.
+    """
+    problems: list[str] = []
+    md = os.path.join(path, SKILL_FILE)
+    if not os.path.isfile(md):
+        return [f"no {SKILL_FILE} in {path}"]
+    block = read_frontmatter(md)
+    if not block:
+        return [
+            f"{SKILL_FILE} has no YAML frontmatter. It must OPEN with a '---' block "
+            "containing `name:` and `description:`. The runtime reads `description` "
+            "to decide whether to load the skill, so without it this skill can "
+            "never fire (a '## Trigger' heading does not work)."
+        ]
+    if "description:" not in block:
+        problems.append(
+            "frontmatter has no `description:` -- that field IS the trigger the "
+            "runtime matches on."
+        )
+    if "name:" not in block:
+        problems.append("frontmatter has no `name:`.")
+    return problems
+
+
+def _load_skill_dirs(skill_dir: Optional[str], *, strict: bool = False) -> dict:
+    """Map ``name -> directory`` for a flat skill folder, skipping unusable ones."""
+    if not skill_dir or not os.path.isdir(skill_dir):
+        if skill_dir and strict:
+            raise FileNotFoundError(f"skill_dir does not exist: {skill_dir}")
+        if skill_dir:
+            logger.warning("skill_dir %s does not exist; starting cold", skill_dir)
+        return {}
+    members: dict[str, str] = {}
+    for path in skill_dirs_in(skill_dir):
+        name = os.path.basename(os.path.normpath(path))
+        problems = validate_skill_dir(path)
+        if problems:
+            msg = f"skipping skill {name!r} in {skill_dir}: " + "; ".join(problems)
+            if strict:
+                raise ValueError(msg)
+            logger.warning("%s", msg)
+            continue
+        members[name] = path
+    return members
+
+
+def render_skill_index(skill_dir: Optional[str]) -> str:
+    """Render the library as ``### <name>`` + frontmatter, for a prompt.
+
+    TRIGGERS ONLY, deliberately. The optimizer agent needs to know what already
+    exists before deciding whether to create something, but reading every full
+    body up front anchors it toward editing them — so the index carries each
+    skill's frontmatter and the agent reads a body only for a skill some real
+    pattern implicates.
+
+    Derived from ``skill_dir`` on every render, so the index and the folder the
+    agent inspects cannot disagree.
+    """
+    members = _load_skill_dirs(skill_dir)
+    if not members:
+        return "(none deployed)"
+    blocks = []
+    for name, path in sorted(members.items()):
+        block = read_frontmatter(os.path.join(path, SKILL_FILE)).strip()
+        blocks.append(f"### {name}\n{path}\n---\n{block}\n---")
+    return "\n\n".join(blocks)

--- a/strands_harness_optimizer/optimizers/__init__.py
+++ b/strands_harness_optimizer/optimizers/__init__.py
@@ -2,6 +2,7 @@
 
 from .base_agentic_optimizer import BaseAgenticOptimizer
 from .optimizer import FormulaOptimizer
+from .skills import SkillLibraryOptimizer
 from .system_prompt import ContrastiveReflectionOptimizer, MultiAgentOptimizer
 
 __all__ = [
@@ -9,4 +10,5 @@ __all__ = [
     "BaseAgenticOptimizer",
     "ContrastiveReflectionOptimizer",
     "MultiAgentOptimizer",
+    "SkillLibraryOptimizer",
 ]

--- a/strands_harness_optimizer/optimizers/__init__.py
+++ b/strands_harness_optimizer/optimizers/__init__.py
@@ -1,7 +1,8 @@
 """Optimization framework — define how to optimize Formula parameters."""
 
+from .base_agentic_optimizer import BaseAgenticOptimizer
 from .optimizer import FormulaOptimizer
-from .system_prompt import BaseAgenticOptimizer, ContrastiveReflectionOptimizer, MultiAgentOptimizer
+from .system_prompt import ContrastiveReflectionOptimizer, MultiAgentOptimizer
 
 __all__ = [
     "FormulaOptimizer",

--- a/strands_harness_optimizer/optimizers/base_agentic_optimizer.py
+++ b/strands_harness_optimizer/optimizers/base_agentic_optimizer.py
@@ -3,7 +3,12 @@ Base class for optimizers that use a strands Agent with shell tools.
 
 Provides infrastructure for writing rollouts to temp folders, creating
 strands Agents with shell tool access, output guardrails, and a
-submit_optimized_prompt tool for reliable prompt extraction.
+submit_optimized_params tool for reliable parameter extraction.
+
+Formula-agnostic: it handles the parts every agentic optimizer needs (which traces
+to look at, how to build and invoke the agent, how to checkpoint) and leaves the
+optimization algorithm to ``step()``. Subclasses live beside it in
+``optimizers/system_prompt/`` and ``optimizers/skills/``.
 """
 
 import json
@@ -24,9 +29,9 @@ from strands import Agent, tool
 from strands.models import BedrockModel
 from strands_tools import shell
 
-from ...formulas import Formula
-from ...utils.guardrails import ToolOutputGuardrail
-from ..optimizer import FormulaOptimizer
+from ..formulas import Formula
+from ..utils.guardrails import ToolOutputGuardrail
+from .optimizer import FormulaOptimizer
 
 logger = logging.getLogger(__name__)
 
@@ -54,17 +59,21 @@ submit_optimized_params(file_path_dict={"system_prompt": "/tmp/system_prompt.txt
 
 class BaseAgenticOptimizer(FormulaOptimizer):
     """
-    Base class for agent-based system prompt optimizers.
+    Base class for agent-based Formula optimizers.
 
     Provides:
     - Writing rollouts to a temp folder as JSON files
     - Creating a strands Agent with shell tool and output guardrail
-    - A submit_optimized_prompt tool for reliable prompt extraction
+    - A submit_optimized_params tool for reliable parameter extraction
     - Stratified sampling of traces by reward
     - Configurable boto, model, and guardrail settings
 
     Subclasses implement step() to define the optimization algorithm,
-    using the inherited helper methods.
+    using the inherited helper methods. None of the above is specific to a
+    particular Formula: ContrastiveReflectionOptimizer submits parameter VALUES,
+    while SkillLibraryOptimizer has its agent write a decision tree, and both
+    reuse everything here. Override ``_get_extra_tools`` to add tools, and
+    ``_get_tools`` to replace the default set.
     """
 
     _DEFAULT_MODEL_CONFIG = {
@@ -188,7 +197,7 @@ class BaseAgenticOptimizer(FormulaOptimizer):
         agent = Agent(
             system_prompt=full_system_prompt,
             model=model,
-            tools=[shell, submit_optimized_params] + self._get_extra_tools(),
+            tools=self._get_tools(submit_optimized_params) + self._get_extra_tools(),
         )
 
         # Register output truncation guardrail
@@ -196,6 +205,19 @@ class BaseAgenticOptimizer(FormulaOptimizer):
         guardrail.register(agent)
 
         return agent
+
+    def _get_tools(self, submit_optimized_params) -> list:
+        """Return the agent's BASE toolset.
+
+        Default is ``[shell, submit_optimized_params]``. Override to replace the
+        set — a subclass whose agent submits its result some other way (writing a
+        folder of files, say) should drop the submit tool rather than be handed one
+        that does nothing for it, since an unused tool in the schema is an
+        invitation to call it.
+
+        To ADD tools while keeping these, override ``_get_extra_tools`` instead.
+        """
+        return [shell, submit_optimized_params]
 
     def _get_extra_tools(self) -> list:
         """Return additional tools for the agent. Override in subclasses."""

--- a/strands_harness_optimizer/optimizers/skills/__init__.py
+++ b/strands_harness_optimizer/optimizers/skills/__init__.py
@@ -1,0 +1,5 @@
+"""Skill optimizers — curate a library of Strands Agent Skills."""
+
+from .skill_library import SkillLibraryOptimizer
+
+__all__ = ["SkillLibraryOptimizer"]

--- a/strands_harness_optimizer/optimizers/skills/skill_library.py
+++ b/strands_harness_optimizer/optimizers/skills/skill_library.py
@@ -1,0 +1,257 @@
+"""
+Skill Library Optimizer.
+
+Curates a whole skill LIBRARY from rollout traces: an agent reads the traces and
+the deployed skills, then decides which skills to create, revise or retire. Pairs
+with :class:`~strands_harness_optimizer.formulas.SkillLibraryFormula`.
+
+Two things differ from :class:`ContrastiveReflectionOptimizer`, and both follow
+from optimizing a set of files rather than a string:
+
+**The agent writes a decision tree, not a value.** ``submit_optimized_params``
+reads each submitted path as a plain-text parameter value, which cannot express
+"create this skill, retire that one". So this optimizer gives the agent an
+``output_folder`` and reads the tree it wrote:
+
+    output_folder/
+      create/<name>/SKILL.md      a skill that did not exist
+      optimize/<name>/SKILL.md    a revision of a deployed skill
+      retire.txt                  one name per line
+      manifest.json               the agent's own record of its reasoning
+
+MERGE and SPLIT need no folders of their own — both are written as a create plus a
+retire of every source.
+
+**"No change" is a correct outcome.** ``ContrastiveReflectionOptimizer`` raises
+when the agent submits nothing, which is right for a prompt: you asked for an
+improvement and got none. A skill library is different — once the recurring
+patterns are covered, the right move is to stop, and churn actively degrades a
+healthy library (each extra rule risks over-fitting one noisy sample). So a
+deliberate SKIP is accepted; only an agent that produced *nothing at all* — no
+decisions and no manifest — is treated as a failure. See :meth:`step`.
+
+The ``output_folder`` also PERSISTS, unlike the temp trace folder. Everything the
+agent writes there (manifest, changelogs, merge notes) is the run's record of why
+the library looks the way it does, and the caller chose the location, so there is
+nothing to clean up or hand back.
+"""
+
+import logging
+import os
+from typing import Optional
+
+from jinja2 import Template
+
+from ...formulas import SkillLibraryFormula
+from ...formulas.skill_library_formula import MANIFEST_FILE, collect_decisions, render_skill_index
+from ...utils.templates import create_template
+from ..base_agentic_optimizer import BaseAgenticOptimizer
+
+logger = logging.getLogger(__name__)
+
+SKILL_SYSTEM_PROMPT_SUFFIX = ""
+
+
+class SkillLibraryOptimizer(BaseAgenticOptimizer):
+    """Optimizer that curates a set of skills from rollout traces.
+
+    Inherits trace sampling, agent construction, the tool-output guardrail and
+    metrics capture from :class:`BaseAgenticOptimizer`; replaces the
+    submit-a-value contract with a decision tree on disk.
+
+    The templates receive exactly three variables:
+
+    ``traces_folder``
+        Temp folder holding the sampled traces. Deleted after the step.
+    ``output_folder``
+        Where to write decisions. Persists.
+    ``skill_folder``
+        The deployed skill set, or ``""`` on a cold start.
+
+    plus ``skill_index`` — the deployed skills' names and frontmatter, rendered
+    from ``skill_folder`` so the two cannot disagree. Templates that build their
+    own index can ignore it.
+
+    Example:
+        formula = SkillLibraryFormula(skill_dir="./skills")
+        optimizer = SkillLibraryOptimizer(
+            formula,
+            system_prompt_template=load_builtin_template("skill_library/system_prompt.jinja"),
+            task_message_template=load_builtin_template("skill_library/task_message.jinja"),
+            output_folder="./runs/iter0",
+        )
+        optimizer.add_rollouts(rollouts)
+        optimizer.add_rewards(rewards)
+        optimizer.step()
+        formula.materialize("./runs/iter0/skill_set")
+
+    Args:
+        formula: The :class:`SkillLibraryFormula` whose set will be optimized.
+        system_prompt_template: Jinja2 template for the curator agent's persona.
+        task_message_template: Jinja2 template for the task message.
+        output_folder: Directory the agent writes its decisions to. Created if
+            absent. Unlike the trace folder this is NOT cleaned up — it is the
+            run's record.
+        **kwargs: Passed to :class:`BaseAgenticOptimizer` (model_config,
+            region_name, boto_config, n_sample_traces, stratified_sampling,
+            success_threshold, max_output_chars).
+    """
+
+    def __init__(
+        self,
+        formula: SkillLibraryFormula,
+        system_prompt_template: "str | Template",
+        task_message_template: "str | Template",
+        output_folder: str,
+        **kwargs,
+    ):
+        if not isinstance(formula, SkillLibraryFormula):
+            raise TypeError(
+                "SkillLibraryOptimizer requires a SkillLibraryFormula (it optimizes a "
+                f"set of skill directories); got {type(formula).__name__}. For a "
+                "single skill's text use SkillFormula with "
+                "ContrastiveReflectionOptimizer."
+            )
+        explicit_suffix = kwargs.pop("system_prompt_suffix", None)
+        super().__init__(formula, **kwargs)
+
+        self.system_prompt_suffix = (
+            explicit_suffix if explicit_suffix is not None else SKILL_SYSTEM_PROMPT_SUFFIX
+        )
+
+        self.output_folder = output_folder
+        self._system_prompt_template = (
+            create_template(system_prompt_template)
+            if isinstance(system_prompt_template, str)
+            else system_prompt_template
+        )
+        self._task_message_template = (
+            create_template(task_message_template)
+            if isinstance(task_message_template, str)
+            else task_message_template
+        )
+        self._last_decisions: dict = {}
+
+        logger.info(
+            "Initialized SkillLibraryOptimizer (model=%s, n_sample_traces=%s, " "output_folder=%s)",
+            self.model_config.get("model_id", "default"),
+            self.n_sample_traces,
+            output_folder,
+        )
+
+    def _get_tools(self, submit_optimized_params) -> list:
+        """Drop ``submit_optimized_params``: this agent writes a decision tree.
+
+        That tool reads each submitted path as one plain-text parameter VALUE,
+        which cannot express "create this skill, retire that one". Leaving it in
+        the schema while the task message asks for a folder of decisions gives the
+        agent two contradictory ways to finish — and the one that "succeeds"
+        silently produces nothing this optimizer can read.
+        """
+        from strands_tools import shell
+
+        return [shell]
+
+    def step(self) -> None:
+        """Curate the library from the accumulated rollouts.
+
+        Samples traces, runs the curator agent against a persistent
+        ``output_folder``, then applies whatever decisions it wrote.
+
+        A step that changes nothing is NOT an error, provided the agent left a
+        manifest explaining why. An agent that wrote neither decisions nor a
+        manifest did not do the work, and that DOES raise — the two look identical
+        from the folder alone and mean opposite things.
+        """
+        if not self._rollouts:
+            logger.warning("No rollouts accumulated, skipping step")
+            return
+
+        os.makedirs(self.output_folder, exist_ok=True)
+        try:
+            indices = self._sample_traces()
+            traces_folder = self._write_traces_to_temp(indices)
+            self._run_curation(traces_folder)
+
+            decisions = collect_decisions(self.output_folder)
+            self._last_decisions = decisions
+            n = sum(len(v) for v in decisions.values())
+
+            if n == 0:
+                if os.path.isfile(os.path.join(self.output_folder, MANIFEST_FILE)):
+                    self._step_count += 1
+                    logger.info(
+                        "Step %d: SKIP -- no qualifying patterns; the library is "
+                        "unchanged (see %s/%s)",
+                        self._step_count,
+                        self.output_folder,
+                        MANIFEST_FILE,
+                    )
+                    return
+                raise RuntimeError(
+                    "The curator agent produced neither decisions nor a "
+                    f"{MANIFEST_FILE} in {self.output_folder}. A deliberate SKIP "
+                    f"must still write {MANIFEST_FILE} saying why, so an agent that "
+                    "failed part-way is not mistaken for one that correctly decided "
+                    "to change nothing."
+                )
+
+            self.formula.update_params({"decisions_dir": self.output_folder})
+            self._step_count += 1
+            self._prompt_history.append({"skills": self.formula.skill_names})
+            logger.info(
+                "Step %d: %d decision(s) applied -> %d skill(s): %s",
+                self._step_count,
+                n,
+                len(self.formula.members),
+                ", ".join(self.formula.skill_names) or "(none)",
+            )
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Error during skill-library optimization: {e}") from e
+        finally:
+            self._cleanup_temp()
+
+    def _run_curation(self, traces_folder: str) -> None:
+        """Render the templates and run the curator agent."""
+        skill_folder = self.formula.get_tunable_params().get("skill_dir", "")
+        template_vars = {
+            "traces_folder": os.path.abspath(traces_folder),
+            "output_folder": os.path.abspath(self.output_folder),
+            "skill_folder": os.path.abspath(skill_folder) if skill_folder else "",
+            "skill_index": render_skill_index(skill_folder or None),
+        }
+        system_prompt = self._system_prompt_template.render(**template_vars)
+        task_message = self._task_message_template.render(**template_vars)
+
+        agent = self._create_agent(system_prompt)
+        self._invoke_agent(agent, task_message)
+
+    @property
+    def last_decisions(self) -> dict:
+        """The decisions read from the most recent step.
+
+        ``{"create": [...], "optimize": [...], "retire": [...]}``; all empty for a
+        SKIP.
+        """
+        return dict(self._last_decisions)
+
+    def get_state(self) -> dict:
+        """Add the skill set and output folder to the inherited checkpoint state."""
+        state = super().get_state()
+        state["output_folder"] = self.output_folder
+        state["skill_names"] = self.formula.skill_names
+        state["skill_dir"] = self.formula.get_tunable_params().get("skill_dir", "")
+        state["last_decisions"] = dict(self._last_decisions)
+        return state
+
+    def load_state(self, state: dict) -> None:
+        """Restore from a checkpoint written by :meth:`get_state`."""
+        super().load_state(state)
+        if "output_folder" in state:
+            self.output_folder = state["output_folder"]
+        if "last_decisions" in state:
+            self._last_decisions = dict(state["last_decisions"])
+        if state.get("skill_dir"):
+            self.formula.update_params({"skill_dir": state["skill_dir"]})

--- a/strands_harness_optimizer/optimizers/system_prompt/__init__.py
+++ b/strands_harness_optimizer/optimizers/system_prompt/__init__.py
@@ -1,7 +1,10 @@
 """System prompt optimizers — optimize system prompts via agent-based reflection."""
 
-from .base_agentic_optimizer import BaseAgenticOptimizer
+from ..base_agentic_optimizer import BaseAgenticOptimizer
 from .contrastive_reflection import ContrastiveReflectionOptimizer
 from .multi_agent import MultiAgentOptimizer
 
+# BaseAgenticOptimizer is Formula-agnostic and now lives one level up (it is shared
+# with optimizers/skills/). Re-exported here so the historical
+# `optimizers.system_prompt.BaseAgenticOptimizer` import keeps working.
 __all__ = ["BaseAgenticOptimizer", "ContrastiveReflectionOptimizer", "MultiAgentOptimizer"]

--- a/strands_harness_optimizer/optimizers/system_prompt/base_agentic_optimizer.py
+++ b/strands_harness_optimizer/optimizers/system_prompt/base_agentic_optimizer.py
@@ -15,6 +15,10 @@ import tempfile
 import time
 from typing import Optional
 
+# Must precede the strands_tools import below: without it shell initializes in
+# interactive-consent mode and the model refuses to run any command.
+os.environ.setdefault("BYPASS_TOOL_CONSENT", "true")
+
 from botocore.config import Config as BotocoreConfig
 from strands import Agent, tool
 from strands.models import BedrockModel
@@ -283,6 +287,27 @@ class BaseAgenticOptimizer(FormulaOptimizer):
     def _write_traces_to_temp(self, indices: list[int]) -> str:
         """Write selected rollouts with rewards to a temp folder as JSON files.
 
+        Each file carries the same episode under TWO shapes, because prompts in the
+        wild read one or the other and a prompt that reads the wrong one silently
+        sees nothing:
+
+          ``data.{messages,reward,metrics,task}``
+              The original nesting. The built-in contrastive_reflection templates
+              read this.
+          ``{reward, response.messages, eval_result, task_id}``
+              The shape a deployed AgentCore runtime returns and that rollout
+              traces are conventionally stored in. Prompts written against real
+              trace folders read ``d["reward"]`` and
+              ``d["response"]["messages"]`` -- with only the nested shape, such a
+              prompt reports `reward=None` and finds zero tool calls for EVERY
+              trace, so its census, its success/failure split and its per-tool
+              statistics are all empty while it reports having analyzed the
+              folder.
+
+        Duplication costs a little disk in a temp folder that is deleted at the end
+        of the step; a prompt silently analyzing nothing costs a whole optimizer
+        run.
+
         Args:
             indices: List of indices into self._rollouts / self._rewards to write.
 
@@ -295,25 +320,41 @@ class BaseAgenticOptimizer(FormulaOptimizer):
             rollout = self._rollouts[i]
             reward_obj = self._rewards[i] if i < len(self._rewards) else None
             reward_value = reward_obj.reward if reward_obj else 0
+            metrics = (
+                {"reward": reward_value, "metadata": reward_obj.metadata} if reward_obj else {}
+            )
             data = {
+                # Legacy nesting -- the built-in contrastive_reflection templates.
                 "data": {
                     "messages": rollout.messages,
                     "reward": reward_value,
-                    "metrics": (
-                        {"reward": reward_value, "metadata": reward_obj.metadata}
-                        if reward_obj
-                        else {}
-                    ),
+                    "metrics": metrics,
                     "task": rollout.data_sample,
                 },
+                # invoke.py / AgentCore-runtime convention.
+                "reward": reward_value,
+                "response": {"messages": rollout.messages},
+                "eval_result": {"reward": reward_value},
+                "task_id": rollout.data_sample.get("task_id", f"rollout_{i:04d}"),
+                "metrics": metrics,
             }
 
-            path = os.path.join(self._temp_dir, f"rollout_{i:04d}.json")
+            path = os.path.join(self._temp_dir, f"{self._trace_filename(rollout, i)}.json")
             with open(path, "w") as f:
                 json.dump(data, f, indent=2, default=str)
 
         logger.info(f"Wrote {len(indices)} traces to {self._temp_dir}")
         return self._temp_dir
+
+    @staticmethod
+    def _trace_filename(rollout, index: int) -> str:
+        """Filesystem-safe name for one trace, preserving a task_id if present."""
+        raw = str(rollout.data_sample.get("task_id") or "").strip()
+        if not raw:
+            return f"rollout_{index:04d}"
+        safe = raw.replace("/", "_").replace("\\", "_").replace("\0", "")
+        # Keep it short enough for any filesystem, and unique regardless of the id.
+        return f"{safe[:180]}_{index:04d}"
 
     def _cleanup_temp(self) -> None:
         """Clean up temporary folders."""

--- a/strands_harness_optimizer/optimizers/system_prompt/contrastive_reflection.py
+++ b/strands_harness_optimizer/optimizers/system_prompt/contrastive_reflection.py
@@ -12,7 +12,7 @@ from jinja2 import Template
 
 from ...formulas import Formula
 from ...utils.templates import create_template
-from .base_agentic_optimizer import BaseAgenticOptimizer
+from ..base_agentic_optimizer import BaseAgenticOptimizer
 
 logger = logging.getLogger(__name__)
 

--- a/strands_harness_optimizer/templates/skill_library/system_prompt.jinja
+++ b/strands_harness_optimizer/templates/skill_library/system_prompt.jinja
@@ -1,0 +1,104 @@
+You maintain a skill library for another agent. That agent solves benchmark tasks and may load skills from your library while it works. You are given its traces and the library. Your only output is edits to the library.
+
+## Task
+
+A skill is one markdown file with two parts that fail independently:
+
+- **trigger** — the `description` frontmatter, phrased "Use when …". Controls *whether* the skill loads.
+- **body** — workflow steps, decision heuristics, mistakes to avoid, domain facts. Controls whether loading *helped*.
+
+A body nobody loads is a trigger defect. A body that loaded and did not help is a body defect. The fixes are disjoint, so you must know which one you have before editing.
+
+A trace is one task attempt, and it carries exactly three things you can use:
+
+1. **reward** — whether the attempt worked.
+2. **skills loaded** — which triggers fired (`skills` tool calls → `input.skill_name`). May be none.
+3. **trajectory** — tool calls, their results, and the agent's own text between them. The only place the *reason* for an outcome appears.
+
+Your edit vocabulary is closed:
+
+| op | meaning |
+|---|---|
+| `create` | add a skill that does not exist |
+| `update` | replace a deployed skill's SKILL.md (record whether you changed the trigger, the body, or both) |
+| `skip` | no edit |
+
+## Analyze
+
+You work from **findings**, not from memory. One finding per trace, written to disk as JSON, then clustered by a shell query over those files. Three passes, in this order.
+
+### Pass A — one finding per trace, library UNREAD
+
+Do every trace before you open a single skill body. This order is not a convenience: if you describe a situation in a deployed skill's vocabulary rather than the task's own words, you corrupt the very signal used to decide whether that skill's trigger could have fired. Once a finding is written, you are done with that trace — do not re-read it.
+
+- **lens** — `winning` if the run succeeded (or a partial that still shows a good path), else `failure`.
+- **root_cause_label** — a SHORT phrase, 3–6 words, naming the winning workflow or the failure cause (`paginate-then-filter`, `refuses-valid-cancellation`). General and reusable, never a sentence tied to this task's specifics. **This is your clustering key**, so label the cause, not the task.
+- **trigger_signal** — the situation in the TASK's or user's own words: the gist plus the concrete phrasing, never internal/API vocabulary. Capture **both** entry points:
+  - the opening framing — how the request or problem is first stated;
+  - the state at the point guidance was actually needed — often mid-conversation, after work is underway ("partway through device steps and the fix has not worked").
+  This is the surface a "Use when …" must match. A trigger that only matches the opening complaint never fires once the conversation has moved on.
+- **skill_scope** — `whole-task-workflow` (governs the task end to end, should load at the start) or `sub-problem` (a branch arising mid-task, loads when it appears).
+- **workflow** — winners only. The ordered steps that produced the reward, with the key decision folded in where it matters ("at X do Y not Z"). 2–6 steps.
+- **failure** — losers only. One statement: the FIRST step that left the winning path, with the message index and the agent's OWN reasoning quoted verbatim, then the correct action instead. Do not invent motivation.
+- **needed_guidance** — one sentence naming what knowledge or procedure would have changed this outcome (for a win: what made it work). Phrase it independently of any existing skill; Pass B checks the bodies against it.
+- **domain_facts_verifiable** — facts the trace EXPLICITLY shows: a tool output, a quoted policy, a system message. 0–3.
+- **domain_facts_inferred** — hypotheses from reward contrast ("this run did X and won"). Tentative, never certain. 0–3.
+
+### Pass B — now read the bodies, and reconcile each finding
+
+Read the FULL body of every deployed skill. Judge relevance from body text alone — a name or a description tells you nothing about what a skill actually says. Then add three fields to each finding. They are separate because they fail separately, and each points at a different op.
+
+- **trigger_match** — would any deployed `description` have matched this finding's `trigger_signal`?
+  `matched-and-loaded` | `should-have-matched-but-did-not` (a discoverability failure) | `no-trigger-applies`
+- **content_covers** — ignoring descriptions entirely, does some body already contain `needed_guidance`?
+  `{"skill": "<name>|null", "verdict": "fully|partially|no"}`. This is the field that separates *bad description, good content* from a *genuine gap*, so decide it on body text only: a skill whose description mentions only symptom A can still fully cover symptom B.
+- **guidance_followed** — only when a skill actually loaded, else null.
+  `followed-and-helped` | `followed-but-still-failed` (say whether the advice was insufficient or wrong) | `ignored` (the body said it, the agent did otherwise) | `contradicted` (the body's advice was actively wrong here — quote the line).
+
+Do not revisit Pass A fields now. If reading a body makes you want to reword a `trigger_signal`, that is the anchoring this pass order exists to prevent.
+
+### Pass C — cluster the findings
+
+Group by `root_cause_label` over the findings files. Never re-open a trace.
+
+- **Failure clusters** — same specific label. Two failures with different causes are two clusters even inside one task family; never lump a family into a catch-all.
+- **Winning clusters** — findings sharing a `workflow` recipe. A canonical workflow many winners follow is a cluster in its own right, whether or not that family also fails.
+- **Shared-prefix clusters — do not miss these.** Winning workflows that look "diverse" often share an identical procedural PREFIX (setup, auth, discovery, pagination) and differ only in the task-specific tail. Cluster on the COMMON PREFIX: if several winners open with the same procedure, that procedure is one codifiable skill and their differing tails are just examples. Do not dismiss it as too diverse or too generic — a multi-step SOP is disqualified only if it is genuinely a single obvious line.
+- Count each cluster's evidence across findings, not per trace. "N findings needed guidance that skill X already contains but X's trigger excluded" is a quantified case, and quantified cases are what you act on.
+
+## Decide
+
+Aggregate the three reconciliation fields over each cluster, then take the row. One cluster, one op. The rows are disjoint — key on `trigger_match` FIRST, because whether a skill loaded determines which of the other two fields is even meaningful.
+
+| `trigger_match` | then | op | part |
+|---|---|---|---|
+| `matched-and-loaded` | `guidance_followed` = `followed-but-still-failed` or `contradicted` | `update` | body |
+| `matched-and-loaded` | `guidance_followed` = `ignored` or `followed-and-helped` | `skip` | — |
+| `should-have-matched-but-did-not` / `no-trigger-applies` | `content_covers` = `fully` or `partially` | `update` | trigger |
+| `should-have-matched-but-did-not` / `no-trigger-applies` | `content_covers` = `no` | `create` | — |
+
+Why that order, and not coverage first: **a skill that loaded already owns this situation.** If its body lacks the guidance, the fix is to add it there (`update` body) — never a `create`, because a new skill would need a trigger overlapping the one that already matched, which Rule 7 forbids. `content_covers` only decides anything when nothing loaded; `guidance_followed` is null in that case and tells you nothing.
+
+The two mistakes this ordering prevents: answering a discoverability failure with a `create` (leaving two skills owning the same content, splitting invocation), and answering a thin body on an already-firing skill with a `create` (same duplication, arrived at from the other side).
+
+`ignored` and `followed-and-helped` are both `skip`: the library already said the right thing, and rewording does not fix adherence.
+
+Act on every cluster that clears the recurrence rule. If none does, emit no edits and record why.
+
+## Rules
+
+1. **Recurrence.** Two or more findings sharing a `root_cause_label` is a candidate. A single finding is actionable ONLY when it is a winning workflow you can see end to end, or a failure with an unambiguously verifiable cause — otherwise it is noise. Do not withhold a well-grounded `create` merely because the count is small, and do not manufacture one from a count of one.
+2. **Write the trigger from `trigger_signal`, covering both entry points.** Every trigger reads: at the start of \<situation\>, OR at any point once \<situation\> is what is being worked on — naming the concrete mid-stream states. A trigger keyed to opening phrases is the single most common invocation failure. This was measured: broadening three triggers to also match mid-conversation state, bodies left byte-identical, raised invocation from 40% to 66% and reward from 0.773 to 0.853.
+3. **Load timing from `skill_scope`.** `whole-task-workflow` → the trigger says "at the start of \<situation\>". `sub-problem` → the trigger names the branch that makes it relevant mid-task.
+4. **One trigger, one skill.** If two clusters' triggers would match the same situation, they are one skill. If one cluster's `trigger_signal` spans two clearly different entry conditions, they are two.
+5. **A cause recurring across situations does NOT become one broad skill.** Write the shared step into each situation's skill. One trigger that fires everywhere helps nowhere.
+6. **Layers vs alternatives, decided by `skills_activated`.** Skills that load TOGETHER are composable layers — keep them separate; stacking outperforms merging. Skills never loaded together that cover one subject are alternatives — fold the weaker one's content into the owner with `update`.
+7. **Update the owner, never add a rival.** If a new skill's "Use when …" would also match a deployed skill's situation, `update` that skill instead. There is no retire, so a duplicate you create is permanent.
+8. **Traceable claims only.** State a domain fact as absolute only from `domain_facts_verifiable`. Anything from `domain_facts_inferred` or reward contrast is a hypothesis — write "prefer X" or "in observed cases X", never "always/never". If a failure needs domain knowledge you cannot verify, skip it and say it needs an authoritative source.
+9. **Annotate evidence strength inline, and let the count pick the wording.** Every substantive line carries its support, and the strength of the claim must match it:
+   - many findings, verifiable → `[HIGH: 7/7 traces]`, phrased as an instruction ("Always check X before Y")
+   - several findings → `[MEDIUM: 4/9]`, phrased as a preference ("When Y, prefer X")
+   - one or two → `[LOW: 1/3]`, phrased as an option ("Consider X if Y"), and only if the cluster cleared Rule 1 at all
+   - conflicting findings → state both branches with the trade-off, not one of them as settled
+   Mark anything from `domain_facts_inferred` `[inferred]` regardless of count. A claim whose scope is not recorded cannot be narrowed by the next iteration — that is how an over-broad trigger becomes permanent.
+10. **Concrete or cut — but complete.** Every line names a specific action, choice, or fact from a trace; delete anything that would read as true for any task on any benchmark. That is a test of each LINE, not a budget for the body: write out the whole ordered procedure. Skills that measurably worked on these benchmarks run 60-150 lines. Only a body past ~300 lines must shrink, and then an `update` that adds a section removes one.

--- a/strands_harness_optimizer/templates/skill_library/task_message.jinja
+++ b/strands_harness_optimizer/templates/skill_library/task_message.jinja
@@ -1,0 +1,251 @@
+Your system instructions carry the three-pass method (`## Analyze`), the op table (`## Decide`), and the rules. This message carries the data, the tools, and the files to write. Work the method there; use what is here to do it.
+
+## Inputs
+
+- **Traces** — `{{ traces_folder }}`, one JSON per task attempt.
+- **Output** — `{{ output_folder }}`, everything you produce.
+{% if skill_folder %}- **Deployed library** — `{{ skill_folder }}`, one folder per skill.
+  **Do not open these until Pass B.** Read a full body with `cat "{{ skill_folder }}/<skill-name>/SKILL.md"`. Names and triggers only, for the census:
+
+{{ skill_index }}
+{% else %}- **Deployed library** — empty. Pass B is trivial: every finding gets `trigger_match: "no-trigger-applies"`, `content_covers: {"skill": null, "verdict": "no"}`, `guidance_followed: null`. Every edit is a `create`, or there are none.
+{% endif %}
+
+Where the three observables sit inside each trace file:
+
+| observable | path in the JSON |
+|---|---|
+| reward | `reward`, else `eval_result.reward`. **Absent** when the attempt errored before scoring |
+| skills loaded | `response.messages[].content[].toolUse` with `name == "skills"` → `input.skill_name` |
+| trajectory | `response.messages[].content[]` blocks: `{text}`, `{toolUse:{name,input}}`, `{toolResult:{status,content}}` |
+
+## Tools
+
+Traces run 30-240KB because tool results dominate the bytes; none is worth reading raw. Write these two extractors once, then work from their output.
+
+```bash
+mkdir -p "{{ output_folder }}/findings"
+
+cat > "{{ output_folder }}/_census.py" << 'PY'
+import json,sys,os
+d=json.load(open(sys.argv[1]))
+r=d.get('reward')
+if r is None and isinstance(d.get('eval_result'),dict): r=d['eval_result'].get('reward')
+err=(d.get('error') or '').replace('\t',' ')[:60]
+bucket='errored' if r is None else ('pass' if r>=1.0 else ('fail' if r<=0.0 else 'partial'))
+msgs=d.get('response',{}).get('messages',[]) if isinstance(d.get('response'),dict) else []
+tools=0; skills=set()
+for m in msgs:
+    for b in (m.get('content',[]) if isinstance(m.get('content'),list) else []):
+        if isinstance(b,dict) and 'toolUse' in b:
+            tools+=1
+            if b['toolUse'].get('name')=='skills':
+                skills.add(b['toolUse'].get('input',{}).get('skill_name',''))
+print(f"{os.path.basename(sys.argv[1])}\t{'NA' if r is None else r}\t{bucket}\t{tools}\t{','.join(sorted(s for s in skills if s)) or 'none'}\t{err}")
+PY
+
+cat > "{{ output_folder }}/_traj.py" << 'PY'
+import json,sys,os
+f=sys.argv[1]; lim=int(sys.argv[2]) if len(sys.argv)>2 else 300
+d=json.load(open(f))
+r=d.get('reward')
+if r is None and isinstance(d.get('eval_result'),dict): r=d['eval_result'].get('reward')
+print(f"### {os.path.basename(f)} reward={r} error={(d.get('error') or 'none')[:80]}")
+msgs=d.get('response',{}).get('messages',[]) if isinstance(d.get('response'),dict) else []
+for i,m in enumerate(msgs):
+    for b in (m.get('content',[]) if isinstance(m.get('content'),list) else []):
+        if not isinstance(b,dict): continue
+        if 'text' in b and b['text'].strip():
+            print(f"[{i}] TEXT {b['text'].strip()[:lim]}")
+        elif 'toolUse' in b:
+            print(f"[{i}] CALL {b['toolUse'].get('name')} {json.dumps(b['toolUse'].get('input',{}))[:lim]}")
+        elif 'toolResult' in b:
+            t=' '.join(x.get('text','') for x in b['toolResult'].get('content',[]) if isinstance(x,dict))
+            print(f"[{i}] RESULT[{b['toolResult'].get('status','?')}] {t.strip()[:lim]}")
+PY
+
+# One row per trace: file, reward, bucket, tool calls, skills loaded, error.
+: > "{{ output_folder }}/census.tsv"
+for f in {{ traces_folder }}/*.json; do
+    case "$(basename "$f")" in summary.json|meta.json|config.json) continue;; esac
+    python3 "{{ output_folder }}/_census.py" "$f" >> "{{ output_folder }}/census.tsv"
+done
+
+# These must match, or the census missed files and every count below is wrong.
+echo "rows: $(wc -l < "{{ output_folder }}/census.tsv")  files: $(ls {{ traces_folder }}/*.json | grep -Ev 'summary|meta|config' | wc -l)"
+
+awk -F'\t' '{n++;b[$3]++; if($3!="errored"){s+=$2;k++}}
+END{printf "traces=%d errored=%d | pass=%d partial=%d fail=%d | mean_reward=%.3f\n",
+n,b["errored"],b["pass"],b["partial"],b["fail"],(k?s/k:0)}' "{{ output_folder }}/census.tsv"
+cut -f5 "{{ output_folder }}/census.tsv" | tr ',' '\n' | sort | uniq -c | sort -rn
+```
+
+Three readings of that output before you go further. The folder is a **deliberately failure-enriched sample** drawn from a larger rollout, so its pass rate is NOT the agent's true rate — use the counts to rank causes against each other, never to report performance. A trace bucketed `errored` never scored; read its error column and support no edit from it unless the trajectory shows the agent caused the stall. A deployed skill with a near-zero count in the last table never fires, so it can only be a trigger defect.
+
+Reading one trace for a Pass-A finding — shape first, then the words that explain it:
+
+```bash
+# Decision shape. Compare a loser against a winner of the closest task type; every trace
+# has a different instruction, so diffing whole trajectories only reports that.
+# QUOTE the filenames. Some benchmarks encode the injected fault in the name, so it
+# contains |, [ and ] -- unquoted, bash reads those as pipes and globs and dies with a
+# syntax error before running anything.
+for t in "<fail-trace>.json" "<pass-trace>.json"; do
+    echo "--- $t"
+    python3 "{{ output_folder }}/_traj.py" "{{ traces_folder }}/$t" 40 \
+      | grep CALL | sed 's/ {.*//' | nl -ba
+done
+
+# Then the loser's reasoning in full, around the index where the shapes parted. The
+# verbatim TEXT line before the diverging CALL is what `failure` must quote.
+python3 "{{ output_folder }}/_traj.py" "{{ traces_folder }}/<fail-trace>.json" 4000 \
+  | sed -n '/^\[11\]/,/^\[15\]/p'
+```
+
+A skipped step, an extra loop, a missing verification, a reversed order — any of those points at an index. If the shapes match, the divergence is in the *content* of one call, so compare inputs at the same step number. Each shell call is a fresh process, so substitute filenames rather than setting variables.
+
+Pass C is a query, not a re-read. Once `findings/` is populated:
+
+```bash
+# cluster sizes by label, and the reconciliation mix inside each
+python3 - <<'PY'
+import json,glob,collections
+F=[json.load(open(f)) for f in glob.glob("{{ output_folder }}/findings/*.json")]
+by=collections.defaultdict(list)
+for x in F: by[x["root_cause_label"]].append(x)
+for lab,g in sorted(by.items(), key=lambda kv:-len(kv[1])):
+    cov=collections.Counter(x["content_covers"]["verdict"] for x in g)
+    tm=collections.Counter(x["trigger_match"] for x in g)
+    gf=collections.Counter(x.get("guidance_followed") or "null" for x in g)
+    lens=collections.Counter(x["lens"] for x in g)
+    print(f"{len(g):>3}  {lab:<34} {dict(lens)} covers={dict(cov)} trigger={dict(tm)} followed={dict(gf)}")
+PY
+```
+
+## Output
+
+### `{{ output_folder }}/findings/<trace-file>.json` — one per trace
+
+Pass A writes every field but the last three; Pass B adds those. Use `null` / `[]` where a field does not apply (`workflow` on a failure, `failure` on a win).
+
+```json
+{
+  "trace_id": "<trace file name>",
+  "reward": 0.0,
+  "lens": "winning|failure",
+  "root_cause_label": "short general reusable phrase",
+  "trigger_signal": "the situation in task-surface words — opening framing AND the state where guidance was needed",
+  "skill_scope": "whole-task-workflow|sub-problem",
+  "skills_activated": [],
+  "workflow": ["ordered step, decision folded in"],
+  "failure": "first wrong step at [index] + verbatim quote -> correct action instead",
+  "needed_guidance": "one sentence, phrased independently of existing skills",
+  "domain_facts_verifiable": [],
+  "domain_facts_inferred": [],
+  "trigger_match": "matched-and-loaded|should-have-matched-but-did-not|no-trigger-applies",
+  "content_covers": {"skill": null, "verdict": "fully|partially|no"},
+  "guidance_followed": "followed-and-helped|followed-but-still-failed|ignored|contradicted|null"
+}
+```
+
+### The edits
+
+One folder per edited skill, each holding a complete SKILL.md. These names are the contract the pipeline reads:
+
+| op | write |
+|---|---|
+| `create` | `{{ output_folder }}/create/<skill-name>/SKILL.md` |
+| `update` | `{{ output_folder }}/optimize/<skill-name>/SKILL.md` — the COMPLETE file, replacing the deployed one |
+| `skip` | nothing |
+
+`<skill-name>` is the folder name and must equal the frontmatter `name:`. An `update` replaces the deployed file wholesale, so anything you leave out is deleted — when changing only the trigger, copy the body verbatim, and vice versa.
+
+```markdown
+---
+name: <skill-name>
+description: "Use when <trigger condition, in the traces' own words> — at the start of <situation>, or at any point once <situation> is what is being worked on. <what it does>."
+---
+
+# <Skill Title>
+
+## Overview
+<2-3 sentences: what this skill helps with, derived from the cluster's findings>
+
+## When to Use
+<the trigger spelled out: the opening framing AND the mid-stream states, from `trigger_signal`>
+
+## Workflow
+<numbered steps, built from the cluster's `workflow`. CONCRETE — a named tool, argument,
+ check or ordering per step, never "refine the search". Annotate each step's support:
+ [HIGH: 7/7 traces] / [MEDIUM: 4/9] / [LOW: 1/3]>
+
+## Decision Heuristics
+<at <the choice point from the divergence>, prefer <what winners did> [MEDIUM: 3/5].
+ Use a table when the choice has more than two branches:>
+
+| situation | prefer | because |
+|---|---|---|
+| <observed state> | <winning action> | <what the traces showed> |
+
+## Common Mistakes to Avoid
+| Agent might think... | But actually... | Instead... |
+|---|---|---|
+| <the false belief, quoted from a `failure`> | <what the trace shows> | <the correct action> |
+
+## Domain Knowledge
+<`domain_facts_verifiable` stated as fact; `domain_facts_inferred` as "prefer X" /
+ "in observed cases X" and marked [inferred]. Never invent a policy or tool behaviour.>
+```
+
+`Overview`, `When to Use` and `Workflow` are always present. Drop `Decision Heuristics`, `Common Mistakes` or `Domain Knowledge` only when the cluster gave you no evidence for them — an empty heading invites the next run to fill it with speculation.
+
+**Write the body out in full.** A skill that fits in 30 lines has almost certainly dropped the workflow detail that makes it usable: on this benchmark family the skills that measurably worked run **60-150 lines** each, carrying the full ordered procedure plus the mistakes table. Terseness is not a virtue here — every line must be concrete and trace-backed, and there are usually many such lines. Compress only when a body exceeds ~300 lines.
+
+### `{{ output_folder }}/manifest.json`
+
+```json
+{
+  "traces": 0,
+  "errored": 0,
+  "mean_reward": 0.0,
+  "findings_written": 0,
+  "clusters": [
+    {"root_cause_label": "label", "lens": "winning|failure", "findings": 0,
+     "trigger_signal": "the shared situation", "skill_scope": "whole-task-workflow|sub-problem",
+     "reconciliation": "the content_covers / trigger_match / guidance_followed counts that decided this",
+     "op": "create|update|skip", "part": "trigger|body|both|null",
+     "skill": "name or null", "why": "one sentence"}
+  ],
+  "edits": [
+    {"op": "create|update", "part": "trigger|body|both|null", "skill": "name",
+     "root_cause_label": "the cluster it answers", "evidence": ["trace.json"],
+     "confidence": "verified|inferred"}
+  ]
+}
+```
+
+Every cluster you formed appears in `clusters`, the rejected ones with `"op": "skip"` and the reason — a rejected cluster is the record that you looked and chose not to act. `edits` holds exactly one entry per file you wrote.
+
+Before you finish:
+
+```bash
+echo "findings: $(ls "{{ output_folder }}/findings"/*.json 2>/dev/null | wc -l)  census rows: $(wc -l < "{{ output_folder }}/census.tsv")"
+python3 -c "
+import json,glob,sys
+bad=0
+for f in glob.glob('{{ output_folder }}/findings/*.json'):
+    d=json.load(open(f))
+    for k in ('root_cause_label','trigger_signal','lens','trigger_match','content_covers','needed_guidance'):
+        if d.get(k) in (None,''): print('missing',k,'in',f); bad=1
+print('findings ok' if not bad else 'FIX THE ABOVE')"
+for d in "{{ output_folder }}"/create/*/ "{{ output_folder }}"/optimize/*/; do
+    [ -d "$d" ] || continue
+    n=$(basename "${d%/}"); f="${d%/}/SKILL.md"
+    grep -q "^name: *$n$" "$f" && echo "ok   $n" || echo "MISMATCH $n vs its frontmatter"
+    grep -qi 'description: *"\?Use when' "$f" || echo "  no 'Use when' trigger: $n"
+done
+python3 -c "import json;json.load(open('{{ output_folder }}/manifest.json'));print('manifest ok')"
+rm -f "{{ output_folder }}/_census.py" "{{ output_folder }}/_traj.py"
+```
+
+The findings count must equal the census row count — a trace with no finding was never analyzed. Fix anything reported, then stop. If you made no edits, leave `create/` and `optimize/` absent; `findings/` and the manifest carry the result.

--- a/tests/formulas/test_skill_library_formula.py
+++ b/tests/formulas/test_skill_library_formula.py
@@ -1,0 +1,343 @@
+"""Tests for SkillLibraryFormula."""
+
+import json
+import os
+
+import pytest
+from strands.hooks.events import BeforeInvocationEvent
+
+from strands_harness_optimizer.formulas import SkillLibraryFormula
+from strands_harness_optimizer.formulas.skill_library_formula import (
+    collect_decisions,
+    read_frontmatter,
+    render_skill_index,
+    validate_skill_dir,
+)
+
+FRONTMATTER = "---\nname: {name}\ndescription: Use when {desc}.\n---\n\n{body}\n"
+
+
+def write_skill(root, name, desc="testing", body="Do the thing.", extra=None):
+    """Create <root>/<name>/SKILL.md, plus optional extra files."""
+    d = os.path.join(str(root), name)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, "SKILL.md"), "w") as f:
+        f.write(FRONTMATTER.format(name=name, desc=desc, body=body))
+    for rel, content in (extra or {}).items():
+        p = os.path.join(d, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as f:
+            f.write(content)
+    return d
+
+
+class TestInit:
+    def test_cold_start_has_no_members(self):
+        formula = SkillLibraryFormula()
+        assert formula.members == {}
+        assert formula.get_tunable_params() == {"skill_dir": ""}
+
+    def test_loads_existing_set(self, tmp_path):
+        write_skill(tmp_path, "alpha")
+        write_skill(tmp_path, "beta")
+        formula = SkillLibraryFormula(str(tmp_path))
+        assert formula.skill_names == ["alpha", "beta"]
+
+    def test_trigger_timings(self):
+        assert SkillLibraryFormula().trigger_timings == [BeforeInvocationEvent]
+
+    def test_tunable_param_is_the_directory(self, tmp_path):
+        write_skill(tmp_path, "alpha")
+        formula = SkillLibraryFormula(str(tmp_path))
+        assert formula.get_tunable_params() == {"skill_dir": str(tmp_path)}
+
+    def test_missing_dir_starts_cold(self, tmp_path):
+        formula = SkillLibraryFormula(str(tmp_path / "nope"))
+        assert formula.members == {}
+
+    def test_missing_dir_raises_in_strict_mode(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            SkillLibraryFormula(str(tmp_path / "nope"), strict=True)
+
+    def test_skill_without_frontmatter_is_skipped(self, tmp_path):
+        write_skill(tmp_path, "good")
+        bad = os.path.join(str(tmp_path), "bad")
+        os.makedirs(bad)
+        with open(os.path.join(bad, "SKILL.md"), "w") as f:
+            f.write("## Trigger\nUse when something.\n")
+        formula = SkillLibraryFormula(str(tmp_path))
+        assert formula.skill_names == ["good"]
+
+    def test_bad_skill_raises_in_strict_mode(self, tmp_path):
+        bad = os.path.join(str(tmp_path), "bad")
+        os.makedirs(bad)
+        with open(os.path.join(bad, "SKILL.md"), "w") as f:
+            f.write("no frontmatter here")
+        with pytest.raises(ValueError, match="frontmatter"):
+            SkillLibraryFormula(str(tmp_path), strict=True)
+
+
+class TestSetAlgebra:
+    """existing - retired - optimized_old + created."""
+
+    def test_create_adds(self, tmp_path):
+        formula = SkillLibraryFormula()
+        out = tmp_path / "out"
+        write_skill(out / "create", "new-skill")
+        formula.update_params({"decisions_dir": str(out)})
+        assert formula.skill_names == ["new-skill"]
+
+    def test_optimize_replaces_in_place(self, tmp_path):
+        existing = tmp_path / "skills"
+        write_skill(existing, "alpha", body="OLD")
+        formula = SkillLibraryFormula(str(existing))
+
+        out = tmp_path / "out"
+        write_skill(out / "optimize", "alpha", body="NEW")
+        formula.update_params({"decisions_dir": str(out)})
+
+        assert formula.skill_names == ["alpha"]
+        # Points at the optimized copy, not the original.
+        assert "out" in formula.members["alpha"]
+
+    def test_retire_removes(self, tmp_path):
+        existing = tmp_path / "skills"
+        write_skill(existing, "alpha")
+        write_skill(existing, "beta")
+        formula = SkillLibraryFormula(str(existing))
+
+        out = tmp_path / "out"
+        os.makedirs(out)
+        (out / "retire.txt").write_text("beta\n")
+        formula.update_params({"decisions_dir": str(out)})
+        assert formula.skill_names == ["alpha"]
+
+    def test_untouched_skills_survive(self, tmp_path):
+        """The agent only reports what CHANGED; the rest must carry over."""
+        existing = tmp_path / "skills"
+        write_skill(existing, "alpha")
+        write_skill(existing, "beta")
+        write_skill(existing, "gamma")
+        formula = SkillLibraryFormula(str(existing))
+
+        out = tmp_path / "out"
+        write_skill(out / "create", "delta")
+        formula.update_params({"decisions_dir": str(out)})
+        assert formula.skill_names == ["alpha", "beta", "delta", "gamma"]
+
+    def test_merge_is_create_plus_retire(self, tmp_path):
+        existing = tmp_path / "skills"
+        write_skill(existing, "search-basic")
+        write_skill(existing, "search-refine")
+        formula = SkillLibraryFormula(str(existing))
+
+        out = tmp_path / "out"
+        write_skill(out / "create", "product-search")
+        os.makedirs(out, exist_ok=True)
+        (out / "retire.txt").write_text("search-basic\nsearch-refine\n")
+        formula.update_params({"decisions_dir": str(out)})
+        assert formula.skill_names == ["product-search"]
+
+    def test_split_is_creates_plus_retire(self, tmp_path):
+        existing = tmp_path / "skills"
+        write_skill(existing, "everything")
+        formula = SkillLibraryFormula(str(existing))
+
+        out = tmp_path / "out"
+        write_skill(out / "create", "part-one")
+        write_skill(out / "create", "part-two")
+        (out / "retire.txt").write_text("everything\n")
+        formula.update_params({"decisions_dir": str(out)})
+        assert formula.skill_names == ["part-one", "part-two"]
+
+    def test_retire_unknown_skill_is_ignored(self, tmp_path):
+        existing = tmp_path / "skills"
+        write_skill(existing, "alpha")
+        formula = SkillLibraryFormula(str(existing))
+
+        out = tmp_path / "out"
+        os.makedirs(out)
+        (out / "retire.txt").write_text("never-deployed\n")
+        formula.update_params({"decisions_dir": str(out)})
+        assert formula.skill_names == ["alpha"]
+
+    def test_no_decisions_leaves_set_unchanged(self, tmp_path):
+        existing = tmp_path / "skills"
+        write_skill(existing, "alpha")
+        formula = SkillLibraryFormula(str(existing))
+        out = tmp_path / "out"
+        os.makedirs(out)
+        formula.update_params({"decisions_dir": str(out)})
+        assert formula.skill_names == ["alpha"]
+
+    def test_malformed_create_is_rejected(self, tmp_path):
+        """A skill the runtime could never load must not enter the set."""
+        formula = SkillLibraryFormula()
+        out = tmp_path / "out"
+        d = out / "create" / "broken"
+        os.makedirs(d)
+        (d / "SKILL.md").write_text("## Trigger\nUse when X.\n")
+        formula.update_params({"decisions_dir": str(out)})
+        assert formula.skill_names == []
+
+    def test_deploy_dir_accepted_as_create_alias(self, tmp_path):
+        formula = SkillLibraryFormula()
+        out = tmp_path / "out"
+        write_skill(out / "deploy", "legacy-named")
+        formula.update_params({"decisions_dir": str(out)})
+        assert formula.skill_names == ["legacy-named"]
+
+    def test_update_params_requires_a_known_key(self):
+        formula = SkillLibraryFormula()
+        with pytest.raises(ValueError, match="decisions_dir"):
+            formula.update_params({"instructions": "nope"})
+
+    def test_skill_dir_replaces_wholesale(self, tmp_path):
+        first = tmp_path / "first"
+        write_skill(first, "alpha")
+        formula = SkillLibraryFormula(str(first))
+
+        second = tmp_path / "second"
+        write_skill(second, "beta")
+        formula.update_params({"skill_dir": str(second)})
+        assert formula.skill_names == ["beta"]
+
+
+class TestMaterialize:
+    def test_writes_flat_folder(self, tmp_path):
+        formula = SkillLibraryFormula()
+        out = tmp_path / "out"
+        write_skill(out / "create", "alpha")
+        write_skill(out / "create", "beta")
+        formula.update_params({"decisions_dir": str(out)})
+
+        dest = formula.materialize(str(tmp_path / "skill_set"))
+        assert sorted(os.listdir(dest)) == ["alpha", "beta"]
+        assert os.path.isfile(os.path.join(dest, "alpha", "SKILL.md"))
+
+    def test_repoints_skill_dir(self, tmp_path):
+        formula = SkillLibraryFormula()
+        write_skill(tmp_path / "out" / "create", "alpha")
+        formula.update_params({"decisions_dir": str(tmp_path / "out")})
+        dest = formula.materialize(str(tmp_path / "skill_set"))
+        assert formula.get_tunable_params() == {"skill_dir": dest}
+
+    def test_carries_subdirectories(self, tmp_path):
+        """A skill may ship scripts/ or resources/ alongside SKILL.md."""
+        formula = SkillLibraryFormula()
+        write_skill(
+            tmp_path / "out" / "create",
+            "alpha",
+            extra={"scripts/check.py": "print('hi')", "resources/notes.md": "# notes"},
+        )
+        formula.update_params({"decisions_dir": str(tmp_path / "out")})
+        dest = formula.materialize(str(tmp_path / "skill_set"))
+        assert os.path.isfile(os.path.join(dest, "alpha", "scripts", "check.py"))
+        assert os.path.isfile(os.path.join(dest, "alpha", "resources", "notes.md"))
+
+    def test_is_idempotent(self, tmp_path):
+        formula = SkillLibraryFormula()
+        write_skill(tmp_path / "out" / "create", "alpha")
+        formula.update_params({"decisions_dir": str(tmp_path / "out")})
+        dest = str(tmp_path / "skill_set")
+        formula.materialize(dest)
+        formula.materialize(dest)
+        assert sorted(os.listdir(dest)) == ["alpha"]
+
+    def test_round_trips_through_a_new_formula(self, tmp_path):
+        formula = SkillLibraryFormula()
+        write_skill(tmp_path / "out" / "create", "alpha")
+        formula.update_params({"decisions_dir": str(tmp_path / "out")})
+        dest = formula.materialize(str(tmp_path / "skill_set"))
+        assert SkillLibraryFormula(dest).skill_names == ["alpha"]
+
+
+class TestFrontmatter:
+    def test_reads_past_a_long_description(self, tmp_path):
+        """A fixed-size window would cut mid-value and lose the closing ---."""
+        long_desc = "x" * 900
+        d = write_skill(tmp_path, "alpha", desc=long_desc)
+        block = read_frontmatter(os.path.join(d, "SKILL.md"))
+        assert "name: alpha" in block
+        assert "description:" in block
+        assert validate_skill_dir(d) == []
+
+    def test_missing_frontmatter_is_reported(self, tmp_path):
+        d = os.path.join(str(tmp_path), "bad")
+        os.makedirs(d)
+        with open(os.path.join(d, "SKILL.md"), "w") as f:
+            f.write("## Trigger\nUse when X.\n")
+        problems = validate_skill_dir(d)
+        assert problems and "frontmatter" in problems[0]
+
+    def test_missing_description_is_reported(self, tmp_path):
+        d = os.path.join(str(tmp_path), "bad")
+        os.makedirs(d)
+        with open(os.path.join(d, "SKILL.md"), "w") as f:
+            f.write("---\nname: bad\n---\n\nbody\n")
+        problems = validate_skill_dir(d)
+        assert any("description:" in p for p in problems)
+
+    def test_missing_skill_md_is_reported(self, tmp_path):
+        d = os.path.join(str(tmp_path), "empty")
+        os.makedirs(d)
+        assert validate_skill_dir(d)
+
+
+class TestRenderSkillIndex:
+    def test_cold_start(self):
+        assert render_skill_index(None) == "(none deployed)"
+        assert render_skill_index("") == "(none deployed)"
+
+    def test_includes_name_path_and_trigger(self, tmp_path):
+        write_skill(tmp_path, "alpha", desc="searching a catalog")
+        index = render_skill_index(str(tmp_path))
+        assert "### alpha" in index
+        assert "searching a catalog" in index
+        assert str(tmp_path) in index
+
+    def test_omits_the_body(self, tmp_path):
+        """Triggers only: reading bodies up front anchors toward editing them."""
+        write_skill(tmp_path, "alpha", body="SECRET_BODY_MARKER")
+        assert "SECRET_BODY_MARKER" not in render_skill_index(str(tmp_path))
+
+
+class TestCollectDecisions:
+    def test_empty_folder(self, tmp_path):
+        assert collect_decisions(str(tmp_path)) == {"create": [], "optimize": [], "retire": []}
+
+    def test_reads_all_three(self, tmp_path):
+        write_skill(tmp_path / "create", "a")
+        write_skill(tmp_path / "optimize", "b")
+        (tmp_path / "retire.txt").write_text("c\nd\n")
+        d = collect_decisions(str(tmp_path))
+        assert len(d["create"]) == 1 and len(d["optimize"]) == 1
+        assert d["retire"] == ["c", "d"]
+
+    def test_ignores_blank_retire_lines(self, tmp_path):
+        (tmp_path / "retire.txt").write_text("a\n\n  \nb\n")
+        assert collect_decisions(str(tmp_path))["retire"] == ["a", "b"]
+
+
+class TestProcess:
+    def test_cold_start_leaves_context_untouched(self):
+        """Returning {"skills": []} would CLEAR a plugin's own skills."""
+        formula = SkillLibraryFormula()
+        ctx = {"system_prompt": "x", "messages": []}
+        assert formula.process(ctx) == ctx
+
+    def test_returns_skills_for_the_adapter(self, tmp_path):
+        write_skill(tmp_path, "alpha")
+        formula = SkillLibraryFormula(str(tmp_path))
+        result = formula.process({"system_prompt": "x", "messages": []})
+        assert "skills" in result
+        assert [s.name for s in result["skills"]] == ["alpha"]
+
+    def test_reflects_an_update(self, tmp_path):
+        write_skill(tmp_path, "alpha")
+        formula = SkillLibraryFormula(str(tmp_path))
+        out = tmp_path / "out"
+        write_skill(out / "create", "beta")
+        formula.update_params({"decisions_dir": str(out)})
+        result = formula.process({"system_prompt": "x", "messages": []})
+        assert sorted(s.name for s in result["skills"]) == ["alpha", "beta"]

--- a/tests/optimizers/test_skill_library_integration.py
+++ b/tests/optimizers/test_skill_library_integration.py
@@ -1,0 +1,194 @@
+"""Integration test for the skill library optimizer with a real Bedrock model.
+
+Drives the full loop against Bedrock -- fabricated rollouts (no environment
+needed), a real curator agent reading the traces and writing a decision tree,
+and the formula applying it. Verifies the pieces the offline unit tests cannot:
+that the built-in prompts actually elicit the ``create/optimize/retire.txt``
+tree, that the agent tolerates the tool-set the optimizer hands it, and that
+``manifest.json`` is written when we expect.
+
+Requires AWS credentials; skipped otherwise.
+"""
+
+import json
+import os
+
+import pytest
+
+from strands_harness_optimizer.datamodels import Reward, Rollout
+from strands_harness_optimizer.formulas import SkillLibraryFormula
+from strands_harness_optimizer.optimizers import SkillLibraryOptimizer
+from strands_harness_optimizer.utils import load_builtin_template
+
+has_aws_credentials = bool(os.environ.get("AWS_ACCESS_KEY_ID"))
+
+
+def _make_rollout(task: str, answer: str, reward: float):
+    """Fabricate a rollout that looks like an invoke.py trace to the curator.
+
+    Real rollouts carry their agent messages under ``response.messages`` in the
+    trace file, and the curator's Phase 3 skeleton extractor
+    (``_traj.py``) reads that path. Building the same shape here means the
+    prompt runs against realistic-looking traces without needing a live agent.
+    """
+    return Rollout(
+        data_sample={"task_id": task[:20], "task": task},
+        messages=[
+            {"role": "user", "content": [{"text": task}]},
+            {"role": "assistant", "content": [{"text": answer}]},
+        ],
+        metadata={
+            "response_text": answer,
+            # invoke.py-style envelope, so a raw JSON read in the curator's
+            # Phase-2 census (grep '"reward"') and its Phase-3 skeleton
+            # (response.messages) both find what they expect.
+            "response": {
+                "messages": [
+                    {"role": "user", "content": [{"text": task}]},
+                    {"role": "assistant", "content": [{"text": answer}]},
+                ],
+            },
+        },
+    ), Reward(reward=reward)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not has_aws_credentials, reason="AWS credentials not available")
+class TestSkillLibraryEndToEnd:
+
+    def test_cold_start_produces_a_decision_tree(self, tmp_path):
+        """The whole loop: rollouts -> curator -> decisions on disk -> set updated.
+
+        Two successful traces solving the same class of task, three failures on
+        another -- enough for the curator to see a recurring pattern in each and,
+        under its own gates, choose CREATE or SKIP. Either is a valid outcome;
+        this test asserts only that the loop completes and the artifacts land
+        where the contract says they will.
+        """
+        formula = SkillLibraryFormula()  # cold start
+        assert formula.skill_names == []
+
+        out_dir = tmp_path / "iter_0"
+        optimizer = SkillLibraryOptimizer(
+            formula,
+            system_prompt_template=load_builtin_template("skill_library/system_prompt.jinja"),
+            task_message_template=load_builtin_template("skill_library/task_message.jinja"),
+            output_folder=str(out_dir),
+            model_config={"model_id": "us.anthropic.claude-sonnet-4-20250514-v1:0"},
+            n_sample_traces=-1,
+        )
+
+        rollouts, rewards = zip(
+            *[
+                _make_rollout("Convert 2 hours to minutes.", "2 hours is 120 minutes.", 1.0),
+                _make_rollout("Convert 3 hours to minutes.", "3 hours is 180 minutes.", 1.0),
+                _make_rollout("What is 15% of 200?", "I think it's around 25 or 30.", 0.0),
+                _make_rollout("What is 20% of 150?", "Not sure, maybe 25?", 0.0),
+                _make_rollout("What is 10% of 400?", "Something like 30 or 50.", 0.0),
+            ]
+        )
+        optimizer.add_rollouts(list(rollouts))
+        optimizer.add_rewards(list(rewards))
+
+        optimizer.step()
+
+        # The curator either wrote decisions or produced a manifest-only SKIP.
+        # Both are legitimate; the loop must have completed and left the run's
+        # record on disk either way.
+        manifest = out_dir / "manifest.json"
+        assert manifest.exists(), (
+            "output_folder must contain manifest.json after step() -- the run's "
+            "record of what the curator decided and why"
+        )
+        parsed = json.loads(manifest.read_text())
+        assert isinstance(
+            parsed, dict
+        ), f"manifest.json must be JSON object, got {type(parsed).__name__}"
+
+        # step_count increments whether decisions were applied or the curator
+        # correctly SKIPped -- both are legitimate outcomes.
+        assert optimizer._step_count == 1
+
+        # If the curator wrote any skills, they must be loadable: the whole point
+        # of frontmatter validation is that a malformed skill is caught here,
+        # not silently at evaluation time.
+        for name, path in formula.members.items():
+            skill_md = os.path.join(path, "SKILL.md")
+            assert os.path.isfile(skill_md), f"{name}: SKILL.md missing at {path}"
+            head = open(skill_md).read()[:2000]
+            assert head.lstrip().startswith("---"), (
+                f"{name}: SKILL.md is missing frontmatter -- the runtime could "
+                "not load it. Formula validation should have rejected this."
+            )
+            assert "description:" in head, (
+                f"{name}: frontmatter has no `description:` -- the runtime "
+                "reads that field to decide whether to load the skill."
+            )
+
+    def test_curator_can_see_deployed_skills(self, tmp_path):
+        """A skill in ``skill_folder`` reaches the prompt through ``skill_index``.
+
+        Populates the library with one obvious-if-read skill, hands the curator
+        rollouts that would have benefited from it, and checks that whatever the
+        curator did, its manifest reflects awareness of the deployed set (either
+        by naming the skill in decisions or by explaining the SKIP in terms of
+        it). Without that awareness the whole "already covered" test in the
+        prompt is a no-op.
+        """
+        # Set up an existing library with one skill.
+        skills = tmp_path / "skills" / "percentage-calculator"
+        skills.mkdir(parents=True)
+        (skills / "SKILL.md").write_text(
+            "---\n"
+            "name: percentage-calculator\n"
+            "description: Use when computing X% of Y. Multiply X/100 by Y.\n"
+            "---\n\n"
+            "# Percentage calculator\n\n"
+            "## Workflow\n"
+            "1. Read X (percent) and Y (base).\n"
+            "2. Compute X/100 * Y.\n"
+            "3. Return the number, no words.\n"
+        )
+        formula = SkillLibraryFormula(str(tmp_path / "skills"))
+        assert formula.skill_names == ["percentage-calculator"]
+
+        out_dir = tmp_path / "iter_0"
+        optimizer = SkillLibraryOptimizer(
+            formula,
+            system_prompt_template=load_builtin_template("skill_library/system_prompt.jinja"),
+            task_message_template=load_builtin_template("skill_library/task_message.jinja"),
+            output_folder=str(out_dir),
+            model_config={"model_id": "us.anthropic.claude-sonnet-4-20250514-v1:0"},
+            n_sample_traces=-1,
+        )
+
+        # Rollouts that would benefit from the deployed skill IF the agent had
+        # actually invoked it. The curator's "already covered" test says: this
+        # is a trigger/discoverability problem, so OPTIMIZE the trigger or SKIP
+        # -- do NOT write a duplicate skill.
+        rollouts, rewards = zip(
+            *[
+                _make_rollout("What is 15% of 200?", "About 25 or 30.", 0.0),
+                _make_rollout("What is 20% of 150?", "Maybe 25.", 0.0),
+                _make_rollout("What is 10% of 400?", "30-something?", 0.0),
+            ]
+        )
+        optimizer.add_rollouts(list(rollouts))
+        optimizer.add_rewards(list(rewards))
+
+        optimizer.step()
+
+        manifest = out_dir / "manifest.json"
+        assert manifest.exists()
+
+        # Whatever the curator chose, the deployed skill's name should appear
+        # somewhere in its record -- either in an OPTIMIZE targeting it, in a
+        # SKIP citing it as already-covering the pattern, or as a covered_by
+        # reference in the partition/cluster tables. If it never appears, the
+        # curator either did not read the index or did not reason about it.
+        blob = manifest.read_text()
+        assert "percentage-calculator" in blob, (
+            "The deployed skill's name did not appear anywhere in manifest.json, "
+            "so the curator either did not receive the skill_index or ignored "
+            f"it. Manifest content:\n{blob[:2000]}"
+        )

--- a/tests/optimizers/test_skill_library_optimizer.py
+++ b/tests/optimizers/test_skill_library_optimizer.py
@@ -1,0 +1,223 @@
+"""Tests for SkillLibraryOptimizer.
+
+The curator agent is stubbed: `_run_curation` is replaced with a function that
+writes the decision tree a real agent would write. That keeps these tests offline
+while still exercising the contract that matters — what the optimizer does with
+what it finds on disk.
+"""
+
+import json
+import os
+
+import pytest
+
+from strands_harness_optimizer.datamodels import Reward, Rollout
+from strands_harness_optimizer.formulas import SkillFormula, SkillLibraryFormula
+from strands_harness_optimizer.optimizers import SkillLibraryOptimizer
+
+FRONTMATTER = "---\nname: {name}\ndescription: Use when {desc}.\n---\n\n{body}\n"
+
+
+def write_skill(root, name, desc="testing", body="Do the thing."):
+    d = os.path.join(str(root), name)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, "SKILL.md"), "w") as f:
+        f.write(FRONTMATTER.format(name=name, desc=desc, body=body))
+    return d
+
+
+def make_optimizer(formula, output_folder, **kwargs):
+    return SkillLibraryOptimizer(
+        formula,
+        system_prompt_template="persona: {{ skill_folder }}",
+        task_message_template="traces: {{ traces_folder }} out: {{ output_folder }}",
+        output_folder=str(output_folder),
+        **kwargs,
+    )
+
+
+def add_rollouts(opt, n=2):
+    """Feed the optimizer enough graded rollouts to have something to sample."""
+    opt.add_rollouts(
+        [
+            Rollout(data_sample={"task_id": f"t{i}"}, messages=[{"role": "user", "content": "x"}])
+            for i in range(n)
+        ]
+    )
+    opt.add_rewards([Reward(reward=1.0 if i % 2 else 0.0) for i in range(n)])
+
+
+def stub_curation(opt, writer):
+    """Replace the LLM call with `writer(output_folder)`."""
+    opt._run_curation = lambda traces_folder: writer(opt.output_folder)
+
+
+class TestInit:
+    def test_rejects_a_non_set_formula(self, tmp_path):
+        """SkillFormula tunes one skill's text; it has no set to curate."""
+        from strands import Skill
+
+        formula = SkillFormula(Skill(name="a", description="d", instructions="i"))
+        with pytest.raises(TypeError, match="SkillLibraryFormula"):
+            make_optimizer(formula, tmp_path / "out")
+
+    def test_accepts_a_skill_library_formula(self, tmp_path):
+        opt = make_optimizer(SkillLibraryFormula(), tmp_path / "out")
+        assert opt.output_folder == str(tmp_path / "out")
+
+    def test_drops_the_submit_tool_instructions(self, tmp_path):
+        """The curator writes files itself; submit_optimized_params does not apply."""
+        opt = make_optimizer(SkillLibraryFormula(), tmp_path / "out")
+        assert opt.system_prompt_suffix == ""
+
+    def test_drops_the_submit_tool_itself(self, tmp_path):
+        """An unused tool in the schema is an invitation to call it."""
+        opt = make_optimizer(SkillLibraryFormula(), tmp_path / "out")
+        agent = opt._create_agent("persona")
+        assert sorted(agent.tool_names) == ["shell"]
+
+
+class TestStep:
+    def test_no_rollouts_is_a_noop(self, tmp_path):
+        opt = make_optimizer(SkillLibraryFormula(), tmp_path / "out")
+        opt.step()  # must not raise
+        assert opt.formula.skill_names == []
+
+    def test_applies_a_create(self, tmp_path):
+        formula = SkillLibraryFormula()
+        opt = make_optimizer(formula, tmp_path / "out")
+        add_rollouts(opt)
+
+        def writer(out):
+            write_skill(os.path.join(out, "create"), "new-skill")
+            with open(os.path.join(out, "manifest.json"), "w") as f:
+                json.dump({"actions": [{"action": "create", "skill_name": "new-skill"}]}, f)
+
+        stub_curation(opt, writer)
+        opt.step()
+        assert formula.skill_names == ["new-skill"]
+        assert opt.last_decisions["create"]
+
+    def test_applies_a_retire(self, tmp_path):
+        existing = tmp_path / "skills"
+        write_skill(existing, "alpha")
+        write_skill(existing, "beta")
+        formula = SkillLibraryFormula(str(existing))
+        opt = make_optimizer(formula, tmp_path / "out")
+        add_rollouts(opt)
+
+        stub_curation(opt, lambda out: open(os.path.join(out, "retire.txt"), "w").write("beta\n"))
+        opt.step()
+        assert formula.skill_names == ["alpha"]
+
+
+class TestSkipIsValid:
+    """A library whose recurring patterns are covered should stop, not churn."""
+
+    def test_manifest_only_is_accepted(self, tmp_path):
+        existing = tmp_path / "skills"
+        write_skill(existing, "alpha")
+        formula = SkillLibraryFormula(str(existing))
+        opt = make_optimizer(formula, tmp_path / "out")
+        add_rollouts(opt)
+
+        def writer(out):
+            with open(os.path.join(out, "manifest.json"), "w") as f:
+                json.dump({"actions": [{"action": "skip", "evidence": "no recurring gaps"}]}, f)
+
+        stub_curation(opt, writer)
+        opt.step()  # must NOT raise
+        assert formula.skill_names == ["alpha"]
+        assert opt.last_decisions == {"create": [], "optimize": [], "retire": []}
+
+    def test_skip_still_counts_as_a_step(self, tmp_path):
+        opt = make_optimizer(SkillLibraryFormula(), tmp_path / "out")
+        add_rollouts(opt)
+        stub_curation(
+            opt, lambda out: open(os.path.join(out, "manifest.json"), "w").write('{"actions": []}')
+        )
+        opt.step()
+        assert opt._step_count == 1
+
+    def test_nothing_at_all_raises(self, tmp_path):
+        """No decisions AND no manifest means the agent did not do the work."""
+        opt = make_optimizer(SkillLibraryFormula(), tmp_path / "out")
+        add_rollouts(opt)
+        stub_curation(opt, lambda out: None)
+        with pytest.raises(RuntimeError, match="manifest"):
+            opt.step()
+
+
+class TestTemplateVars:
+    def test_receives_the_three_inputs_plus_index(self, tmp_path):
+        write_skill(tmp_path / "skills", "alpha", desc="searching a catalog")
+        formula = SkillLibraryFormula(str(tmp_path / "skills"))
+
+        seen = {}
+        opt = SkillLibraryOptimizer(
+            formula,
+            system_prompt_template="{{ skill_index }}",
+            task_message_template=("{{ traces_folder }}|{{ output_folder }}|{{ skill_folder }}"),
+            output_folder=str(tmp_path / "out"),
+        )
+
+        def fake_create_agent(system_prompt):
+            seen["system"] = system_prompt
+
+            class _A:
+                pass
+
+            return _A()
+
+        opt._create_agent = fake_create_agent
+        opt._invoke_agent = lambda agent, message: seen.setdefault("task", message)
+        add_rollouts(opt)
+        stub = opt._run_curation
+        # Run the real _run_curation, with the agent construction/invocation faked.
+        opt._run_curation = stub
+        try:
+            opt.step()
+        except RuntimeError:
+            pass  # the fake agent writes nothing; we only care about the render
+
+        assert "searching a catalog" in seen["system"]
+        traces, out, skills = seen["task"].split("|")
+        assert os.path.isabs(out) and out.endswith("out")
+        assert skills.endswith("skills")
+        assert "contrastive_traces_" in traces
+
+    def test_cold_start_passes_an_empty_skill_folder(self, tmp_path):
+        seen = {}
+        opt = SkillLibraryOptimizer(
+            SkillLibraryFormula(),
+            system_prompt_template="x",
+            task_message_template="[{{ skill_folder }}][{{ skill_index }}]",
+            output_folder=str(tmp_path / "out"),
+        )
+        opt._create_agent = lambda sp: object()
+        opt._invoke_agent = lambda agent, message: seen.setdefault("task", message)
+        add_rollouts(opt)
+        try:
+            opt.step()
+        except RuntimeError:
+            pass
+        assert seen["task"] == "[][(none deployed)]"
+
+
+class TestCheckpointing:
+    def test_round_trips_the_set(self, tmp_path):
+        existing = tmp_path / "skills"
+        write_skill(existing, "alpha")
+        formula = SkillLibraryFormula(str(existing))
+        opt = make_optimizer(formula, tmp_path / "out")
+        state = json.loads(json.dumps(opt.get_state()))  # must be JSON-able
+
+        restored = make_optimizer(SkillLibraryFormula(), tmp_path / "elsewhere")
+        restored.load_state(state)
+        assert restored.formula.skill_names == ["alpha"]
+        assert restored.output_folder == str(tmp_path / "out")
+
+    def test_state_records_skill_names(self, tmp_path):
+        write_skill(tmp_path / "skills", "alpha")
+        opt = make_optimizer(SkillLibraryFormula(str(tmp_path / "skills")), tmp_path / "out")
+        assert opt.get_state()["skill_names"] == ["alpha"]


### PR DESCRIPTION
## Summary

Adds a Formula and optimizer that tune the set of skills an agent has — which skills should exist at all — rather than the wording of one skill, plus the runtime support to deliver a curated library back to the AppWorld and WebShop examples.

- SkillLibraryFormula owns a library of skill directories, so its tunable parameter is a directory rather than text: a skill is a tree of files (SKILL.md plus any scripts/ or resources/) and its membership is part of what gets optimized. SkillFormula tunes one skill's description/instructions and cannot create a skill, retire one, or change how many exist — that is a diff over a set, which a mapping of skill text cannot express. update_params({"decisions_dir": ...}) resolves existing - retired - optimized_old + created; materialize() collects the result into the flat <name>/SKILL.md folder an agent loads, copying whole trees so supporting files survive. process() serves in-process agents through the adapter, rebuilding Skill objects each invocation because AgentSkills reads a filesystem path only at init_agent time. Frontmatter is validated before a skill enters the set — the runtime reads description to decide whether to load a skill, so one written without it never fires and evaluating it measures the unmodified baseline.
- SkillLibraryOptimizer reuses BaseAgenticOptimizer's sampling, agent construction, guardrail and metrics, and replaces the submit-a-value contract with a decision tree on disk: create/<name>/SKILL.md, optimize/<name>/SKILL.md, retire.txt, manifest.json. MERGE and SPLIT need no cases of their own — both are a create plus a retire of every source. It overrides _get_tools to drop submit_optimized_params, which reads a path as one plain-text value and cannot express create-and-retire. Two deliberate differences from ContrastiveReflectionOptimizer: a step that changes nothing is accepted when the agent left a manifest saying why (an agent that wrote neither still raises — on disk those look identical and mean opposite things), and output_folder persists as the run's record. Both are exported from strands_harness_optimizer.optimizers.
- templates/skill_library/ carries the curator pipeline: a per-trace census, per-trace findings from one read each, then grouping into situations and clustering by root cause. Situations are derived from trace content only, never from filenames, which may encode ground truth the agent under test never saw. Templates take traces_folder, output_folder, skill_folder, and skill_index (rendered from skill_folder, so the two cannot disagree).
- BaseAgenticOptimizer moves from optimizers/system_prompt/ up to optimizers/base_agentic_optimizer.py — nothing in it is system-prompt specific, and it is now shared with optimizers/skills/. All three import paths resolve to the same class; optimizers.system_prompt re-exports it so the historical path keeps working. _get_tools() is new, and returns the base toolset so a subclass can replace it; _get_extra_tools only appends.
- Two latent bugs in BaseAgenticOptimizer, both affecting ContrastiveReflectionOptimizer too. BYPASS_TOOL_CONSENT is now set at import time before from strands_tools import shell — without it shell initializes in interactive-consent mode and the model refuses to run any command, so an agent given shell produces nothing. And _write_traces_to_temp wrote traces only as nested data.{messages,reward}; a prompt written against a real rollout folder reads d["reward"] and d["response"]["messages"] — the shape a deployed AgentCore runtime returns — and against the nested form sees no reward and no tool calls for every trace while reporting that it analyzed the folder. Traces now carry both shapes, and filenames preserve the sample's task_id for attribution.
- examples/{appworld,webshop}/ gain --skills on run_example.sh and a *_skill_library_optimization.py client. Both runtimes accepted a system_prompt per invocation but had no way to receive a skill library, so a curator could produce skills with nowhere to send them. Skills travel inline as skills_folder = [{path, content}] rather than as an S3 pointer: no bucket or extra IAM, and a saved trace records the skill text the agent read. Runtime changes are additive and mirrored across both (their _local.py files are byte-identical by existing convention) — create_strands_agent(..., plugins=None), and install_skills() which rebuilds the AgentSkills plugin rather than mutating it. app.py echoes skills_applied, so a client can distinguish "the skills did not help" from "the skills never loaded".

## Verification

- SkillLibraryFormula and SkillLibraryOptimizer: 52 offline tests — set algebra including merge and split, frontmatter validation and rejection, materialize() idempotency and subdirectory carry-through, skip-versus-failure, template variables, checkpoint round-trip. Suite 106 passed, 6 skipped.
- Curator loop live against Bedrock (2 tests marked integration, skipped without credentials): cold start produces a valid decision tree; with a skill already deployed the curator diagnoses non-activation as a trigger problem and optimizes the trigger rather than writing a duplicate.
- Full loop over 20 real agent traces from a multi-turn benchmark: the curator grouped them into three distinct situations and created one skill per situation, matching a known-good result from an earlier implementation of the same pipeline.
- Client-to-runtime round-trip against a stub /invocations endpoint: the request log shows iteration 0 sending no skills and the final evaluation sending the curated one, and the curator diagnosed the injected failure from tool-call structure alone.
- install_skills against strands-agents 1.47 and the runtimes' pinned 1.33 — install, retire, clear, subdirectory carry-through, path-traversal guard, and the malformed-frontmatter warning.

## Commits

- Fix two latent bugs in BaseAgenticOptimizer
- Move BaseAgenticOptimizer up a level; add a _get_tools seam
- Add skill-library optimization: SkillLibraryFormula + SkillLibraryOptimizer
- Curate skill libraries on the AppWorld and WebShop runtimes